### PR TITLE
support different template delimiters

### DIFF
--- a/cmd/runtimecfg.go
+++ b/cmd/runtimecfg.go
@@ -88,10 +88,20 @@ func main() {
 				return err
 			}
 
-			return render.Render(outDir, args[1:], config)
+			leftDelim, err := cmd.Flags().GetString("left-delimiter")
+			if err != nil {
+				return err
+			}
+			rightDelim, err := cmd.Flags().GetString("right-delimiter")
+			if err != nil {
+				return err
+			}
+			return render.Render(outDir, args[1:], config, leftDelim, rightDelim)
 		},
 	}
 	renderCmd.Flags().StringP("out-dir", "o", "", "Directory where the templates will be rendered")
+	renderCmd.Flags().String("left-delimiter", "", "String to be used as left delimiter for variables in the templates")
+	renderCmd.Flags().String("right-delimiter", "", "String to be used as right delimiter for variables in the templates")
 
 	rootCmd.PersistentFlags().Bool("verbose", false, "Display extra information about the rendering")
 	rootCmd.PersistentFlags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")

--- a/test/data/bracket_delim/Corefile.tmpl
+++ b/test/data/bracket_delim/Corefile.tmpl
@@ -1,0 +1,12 @@
+. {
+    errors
+    health
+    mdns [[.Cluster.Domain]] 0 [[.Cluster.Name]]
+    forward . /etc/coredns/resolv.conf
+    cache 30
+    reload
+    hosts /etc/coredns/api-int.hosts [[.Cluster.Domain]] {
+        [[.Cluster.APIVIP]] api-int.[[.Cluster.Domain]]
+        fallthrough
+    }
+}

--- a/test/data/bracket_delim/config.hcl.tmpl
+++ b/test/data/bracket_delim/config.hcl.tmpl
@@ -1,0 +1,11 @@
+bind_address = "[[.NonVirtualIP]]"
+collision_avoidance = "hostname"
+
+service {
+    name = "[[.Cluster.Name]] Workstation"
+    host_name = "[[.ShortHostname]]"
+    type = "_workstation._tcp"
+    domain = "local."
+    port = 42424
+    ttl = 3200
+}

--- a/test/data/bracket_delim/keepalived.conf.tmpl
+++ b/test/data/bracket_delim/keepalived.conf.tmpl
@@ -1,0 +1,53 @@
+vrrp_script chk_ocp {
+    script "curl -o /dev/null -kLs https://0:6443/readyz"
+    interval 1
+    weight 50
+}
+
+vrrp_script chk_dns {
+    script "host -t SRV _etcd-server-ssl._tcp.[[.Cluster.Domain]] localhost"
+    interval 1
+    weight 50
+}
+
+vrrp_script chk_ingress {
+    script "curl -o /dev/null -kLs https://0:1936/healthz"
+    interval 1
+    weight 50
+}
+
+vrrp_instance [[.Cluster.Name]]_API {
+    state BACKUP
+    interface [[.VRRPInterface]]
+    virtual_router_id [[.Cluster.APIVirtualRouterID]]
+    priority 40
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass [[.Cluster.Name]]_api_vip
+    }
+    virtual_ipaddress {
+        [[.Cluster.APIVIP]]/[[.Cluster.VIPNetmask]]
+    }
+    track_script {
+        chk_ocp
+    }
+}
+
+vrrp_instance [[.Cluster.Name]]_INGRESS {
+    state BACKUP
+    interface [[.VRRPInterface]]
+    virtual_router_id [[.Cluster.IngressVirtualRouterID]]
+    priority 40
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass cluster_uuid_ingress_vip
+    }
+    virtual_ipaddress {
+        [[.Cluster.IngressVIP]]/[[.Cluster.VIPNetmask]]
+    }
+    track_script {
+        chk_ingress
+    }
+}


### PR DESCRIPTION
In case we need to render files that already went through some golang rendering,
it would be good to use different delimiters to preclude the need for escaping
and to increase the visual difference between the two kinds of variables to
render.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>