### PR TITLE
Add stabilization mechanism to monitor logic

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -54,7 +54,7 @@ func main() {
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	rootCmd.Flags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
 	rootCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
-	rootCmd.Flags().Duration("check-interval", time.Second*15, "Time between monitor checks")
+	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -75,3 +75,24 @@ func IsKubernetesHealthy(port uint16) (bool, error) {
 
 	return string(body) == "ok", nil
 }
+
+func AlarmStabilization(cur_alrm bool, cur_defect bool, consecutive_ctr uint8, on_threshold uint8, off_threshold uint8) (bool, uint8) {
+	var new_alrm bool = cur_alrm
+	var threshold uint8
+
+	if cur_alrm != cur_defect {
+		consecutive_ctr++
+		if cur_alrm {
+			threshold = off_threshold
+		} else {
+			threshold = on_threshold
+		}
+		if consecutive_ctr >= threshold {
+			new_alrm = !cur_alrm
+			consecutive_ctr = 0
+		}
+	} else {
+		consecutive_ctr = 0
+	}
+	return new_alrm, consecutive_ctr
+}


### PR DESCRIPTION
Monitor checks periodically for changes in masters topology, K8S API health via Haproxy
and updates load balancer configuration correspondingly.
To make the monitoring process more robust, this commit adds stabilization mechanism to
the periodic checks, means that Monitor will update load balancer configuration
only after it detects a change for N consecutive intervals.