### PR TITLE
Add dynkeepalived to solve interface changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ network_closure.sh
 # binary
 runtimecfg
 monitor
+dynkeepalived

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor cmd/runtimecfg/runtimecfg.go
+RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
 RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/iptables /usr/bin
 
 ENTRYPOINT ["/usr/bin/runtimecfg"]

--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
+)
+
+var log = logrus.New()
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:   "dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config",
+		Short: "Monitors runtime external interface for keepalived and reloads if it changes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				cmd.Help()
+				return nil
+			}
+			apiVip, err := cmd.Flags().GetIP("api-vip")
+			if err != nil {
+				apiVip = nil
+			}
+			ingressVip, err := cmd.Flags().GetIP("ingress-vip")
+			if err != nil {
+				ingressVip = nil
+			}
+			dnsVip, err := cmd.Flags().GetIP("dns-vip")
+			if err != nil {
+				dnsVip = nil
+			}
+
+			checkInterval, err := cmd.Flags().GetDuration("check-interval")
+			if err != nil {
+				return err
+			}
+			clusterConfigPath, err := cmd.Flags().GetString("cluster-config")
+			if err != nil {
+				return err
+			}
+
+			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, dnsVip, checkInterval)
+		},
+	}
+	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
+	rootCmd.Flags().Duration("check-interval", time.Second*10, "Time between keepalived watch checks")
+	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Failed due to %s", err)
+	}
+}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -1,0 +1,69 @@
+package monitor
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/config"
+	"github.com/openshift/baremetal-runtimecfg/pkg/render"
+	"github.com/sirupsen/logrus"
+)
+
+const keepalivedControlSock = "/var/run/keepalived/keepalived.sock"
+
+func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip, dnsVip net.IP, interval time.Duration) error {
+	var prevConfig *config.Node
+
+	signals := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+
+	signal.Notify(signals, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGINT)
+	go func() {
+		<-signals
+		done <- true
+	}()
+
+	conn, err := net.Dial("unix", keepalivedControlSock)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		default:
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, apiVip, ingressVip, dnsVip, 0, 0, 0)
+			if err != nil {
+				return err
+			}
+			if prevConfig == nil || prevConfig.VRRPInterface != newConfig.VRRPInterface {
+				log.WithFields(logrus.Fields{
+					"new config": newConfig,
+				}).Info("Config change detected")
+				err = render.RenderFile(cfgPath, templatePath, newConfig)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"config": newConfig,
+					}).Error("Failed to render Keepalived configuration")
+					return err
+				}
+
+				_, err = conn.Write([]byte("reload\n"))
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"socket": keepalivedControlSock,
+					}).Error("Failed to write reload to Keepalived container control socket")
+					return err
+				}
+			}
+			prevConfig = &newConfig
+			time.Sleep(interval)
+		}
+	}
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -5,13 +5,13 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"sort"
 	"syscall"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/baremetal-runtimecfg/pkg/config"
 	"github.com/openshift/baremetal-runtimecfg/pkg/render"
 	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
 )
@@ -20,76 +20,12 @@ const haproxyMasterSock = "/var/run/haproxy/haproxy-master.sock"
 
 var log = logrus.New()
 
-type Backend struct {
-	Host    string
-	Address string
-	Port    uint16
-}
-
-type ApiLBConfig struct {
-	ApiPort  uint16
-	LbPort   uint16
-	StatPort uint16
-	Backends []Backend
-}
-
 type RuntimeConfig struct {
-	LBConfig *ApiLBConfig
-}
-
-func getSortedBackends(domain string) (backends []Backend, err error) {
-	srvs, err := utils.GetEtcdSRVMembers(domain)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"err": err,
-		}).Info("Failed to get Etcd SRV members")
-		srvs = []*net.SRV{}
-		err = nil
-	}
-
-	for _, srv := range srvs {
-		addr, err := utils.GetFirstAddr(srv.Target)
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				"member": srv.Target,
-			}).Error("Failed to get address for member")
-			continue
-		}
-		backends = append(backends, Backend{Host: srv.Target, Address: addr, Port: srv.Port})
-	}
-	sort.Slice(backends, func(i, j int) bool {
-		return backends[i].Address < backends[j].Address
-	})
-	return backends, err
-}
-
-func GetLBConfig(domain string, apiPort, lbPort, statPort uint16) (ApiLBConfig, error) {
-	config := ApiLBConfig{
-		ApiPort:  apiPort,
-		LbPort:   lbPort,
-		StatPort: statPort,
-	}
-	backends, err := getSortedBackends(domain)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"domain": domain,
-		}).Error("Failed to retrieve API member information")
-		return config, err
-	}
-
-	// The backends port is the Etcd one, but we need to loadbalance the API one
-	for i := 0; i < len(backends); i++ {
-		backends[i].Port = apiPort
-	}
-	config.Backends = backends
-	log.WithFields(logrus.Fields{
-		"config": config,
-	}).Debug("Config for LB configuration retrieved")
-	return config, nil
+	LBConfig *config.ApiLBConfig
 }
 
 func Monitor(clusterName, clusterDomain, templatePath, cfgPath, apiVip string, apiPort, lbPort, statPort uint16, interval time.Duration) error {
-	var oldConfig, newConfig *ApiLBConfig
+	var oldConfig, newConfig *config.ApiLBConfig
 	var k8sIsHealthy bool = false
 	signals := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
@@ -115,7 +51,7 @@ func Monitor(clusterName, clusterDomain, templatePath, cfgPath, apiVip string, a
 		case <-done:
 			return nil
 		default:
-			config, err := GetLBConfig(domain, apiPort, lbPort, statPort)
+			config, err := config.GetLBConfig(domain, apiPort, lbPort, statPort)
 			if err != nil {
 				return err
 			}

--- a/test/data/config.hcl.tmpl
+++ b/test/data/config.hcl.tmpl
@@ -11,7 +11,7 @@ service {
 }
 
 service {
-    name = "{{`{{.Cluster.Name}}`}} Etcd"
+    name = "{{.Cluster.Name}} Etcd"
     host_name = "{{.EtcdShortHostname}}.local."
     type = "_etcd-server-ssl._tcp"
     domain = "local."


### PR DESCRIPTION
Using runtimecfg render for keepalived has the issue that on 1.x
keepalived versions there's no dynamic interfaces and in case the
interface changes, keepalived will stop doing its job.

Thanks to dynkeepalived, it is now possible to have it monitor the
interface and dynamically send a reload to a unix socket that can be
used to trigger a keepalived reload in the keepalived container.

This is meant to be used from a side-car to the keepalived pod.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>