### PR TITLE
Tweak VRID calculation to avoid 0

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -159,9 +159,15 @@ func GetConfig(kubeconfigPath, clusterConfigPath string, apiVip net.IP, ingressV
 	// keepalived. This is safe because fletcher8 can never return 255 due to
 	// the modulo arithmetic that happens. The largest value it can return is
 	// 238 (0xEE).
-	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-api") + 1
-	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-dns") + 1
-	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-ingress") + 1
+	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-api") + 1
+	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-dns") + 1
+	if node.Cluster.DNSVirtualRouterID == node.Cluster.APIVirtualRouterID {
+		node.Cluster.DNSVirtualRouterID++
+	}
+	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-ingress") + 1
+	for node.Cluster.IngressVirtualRouterID == node.Cluster.DNSVirtualRouterID || node.Cluster.IngressVirtualRouterID == node.Cluster.APIVirtualRouterID {
+		node.Cluster.IngressVirtualRouterID++
+	}
 
 	if clusterConfigPath != "" {
 		masterAmount, err := getClusterConfigMasterAmount(clusterConfigPath)

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -155,9 +155,13 @@ func GetConfig(kubeconfigPath, clusterConfigPath string, apiVip net.IP, ingressV
 	node.Cluster.Name = clusterName
 	node.Cluster.Domain = clusterDomain
 
-	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-api")
-	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-dns")
-	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-ingress")
+	// Add one to the fletcher8 result because 0 is an invalid vrid in
+	// keepalived. This is safe because fletcher8 can never return 255 due to
+	// the modulo arithmetic that happens. The largest value it can return is
+	// 238 (0xEE).
+	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-api") + 1
+	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-dns") + 1
+	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-ingress") + 1
 
 	if clusterConfigPath != "" {
 		masterAmount, err := getClusterConfigMasterAmount(clusterConfigPath)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,8 +13,8 @@ import (
 func FletcherChecksum8(inp string) uint8 {
 	var ckA, ckB uint8
 	for i := 0; i < len(inp); i++ {
-		ckA = (ckA + inp[i]) & 0xf
-		ckB = (ckB + ckA) & 0xf
+		ckA = (ckA + inp[i]) % 0xf
+		ckB = (ckB + ckA) % 0xf
 	}
 	return (ckB << 4) | ckA
 }


### PR DESCRIPTION
This change modifies how we calculate the fletcher8 checksum to
match the online calculators (for example, [0]). This has two
important effects:

1) The maximum value it can return is now 0xEE rather than 0xFF.
   This is a documented limitation of the fletcher algorithm because
   it uses modulo operations and 0xF % 0xF is 0, not 0xF, so it's
   impossible to get a 0xF byte. Unfortunately, this does reduce the
   id space available.

2) Because the algorithm will not return 255, we can safely add one
   to the resulting value to ensure we don't end up with a VRID of
   0. 0 is not a valid VRID for keepalived, as reported in #21.

0: https://gchq.github.io/CyberChef/#recipe=Fletcher-8_Checksum()&input=bDN2dnFxbmktZjIxY2EtZG5z