### PR TITLE
Allow passing a path to resolvconf

### DIFF
--- a/cmd/runtimecfg/runtimecfg.go
+++ b/cmd/runtimecfg/runtimecfg.go
@@ -56,7 +56,11 @@ func main() {
 				return err
 			}
 
-			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
+			resolveConfPath, err := cmd.Flags().GetString("resolvconf-path")
+			if err != nil {
+				return err
+			}
+			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
 			if err != nil {
 				return err
 			}
@@ -104,7 +108,11 @@ func main() {
 			if err != nil {
 				return err
 			}
-			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
+			resolveConfPath, err := cmd.Flags().GetString("resolvconf-path")
+			if err != nil {
+				return err
+			}
+			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
 			if err != nil {
 				return err
 			}
@@ -134,6 +142,7 @@ func main() {
 	rootCmd.PersistentFlags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	rootCmd.PersistentFlags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
 	rootCmd.PersistentFlags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
+	rootCmd.PersistentFlags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 
 	rootCmd.AddCommand(displayCmd)
 	rootCmd.AddCommand(renderCmd)

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -57,8 +57,8 @@ type Node struct {
 	DNSUpstreams      []string
 }
 
-func getDNSUpstreams() (upstreams []string, err error) {
-	dnsFile, err := os.Open("/etc/resolv.conf")
+func getDNSUpstreams(resolvConfPath string) (upstreams []string, err error) {
+	dnsFile, err := os.Open(resolvConfPath)
 	if err != nil {
 		return upstreams, err
 	}
@@ -142,7 +142,7 @@ func getClusterConfigMapInstallConfig(configPath string) (installConfig types.In
 	return ic, err
 }
 
-func GetConfig(kubeconfigPath, clusterConfigPath string, apiVip net.IP, ingressVip net.IP, dnsVip net.IP, apiPort, lbPort, statPort uint16) (node Node, err error) {
+func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVip net.IP, ingressVip net.IP, dnsVip net.IP, apiPort, lbPort, statPort uint16) (node Node, err error) {
 	// Try cluster-config.yml first
 	clusterName, clusterDomain, err := getClusterConfigClusterNameAndDomain(clusterConfigPath)
 	if err != nil {
@@ -198,7 +198,7 @@ func GetConfig(kubeconfigPath, clusterConfigPath string, apiVip net.IP, ingressV
 	}
 	node.NonVirtualIP = nonVipAddr.IP.String()
 
-	resolvConfUpstreams, err := getDNSUpstreams()
+	resolvConfUpstreams, err := getDNSUpstreams(resolvConfPath)
 	if err != nil {
 		return node, err
 	}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -38,7 +38,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		case <-done:
 			return nil
 		default:
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, apiVip, ingressVip, dnsVip, 0, 0, 0)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVip, ingressVip, dnsVip, 0, 0, 0)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This will enable use cases where the upstreams you want in coredns
runtime are different than those that should be used by kubelet for the
pods.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>