### PR TITLE
Check that go fmt has no changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./pkg/... ./cmd/...
+	git diff --exit-code
 
 .PHONY: vet
 vet: ## Run go vet against code


### PR DESCRIPTION
Previously the makefile only ran go fmt but didn't verify whether it
had to make changes. This adds a git diff --exit-code call to the
target so it will fail if the code was not formatted properly.