### PR TITLE
Verify that Iptable rule being deleted

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -41,7 +41,6 @@ func Monitor(clusterName, clusterDomain, templatePath, cfgPath, apiVip string, a
 	signal.Notify(signals, syscall.SIGINT)
 	go func() {
 		<-signals
-		cleanHAProxyPreRoutingRule(apiVip, apiPort, lbPort)
 		done <- true
 	}()
 
@@ -56,6 +55,7 @@ func Monitor(clusterName, clusterDomain, templatePath, cfgPath, apiVip string, a
 	for {
 		select {
 		case <-done:
+			cleanHAProxyPreRoutingRule(apiVip, apiPort, lbPort)
 			return nil
 		default:
 			config, err := config.GetLBConfig(domain, apiPort, lbPort, statPort)


### PR DESCRIPTION
Due to multi-process implementation of the monitor code (it's a corner case),
 we may hit a race condition and as a result of this race, the iptable rule won't be deleted.
This fix verifies that the iptable rule is deleted.