### PR TITLE
Bug 1775123: Prevent collisions between VRIDs

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -155,9 +155,19 @@ func GetConfig(kubeconfigPath, clusterConfigPath string, apiVip net.IP, ingressV
 	node.Cluster.Name = clusterName
 	node.Cluster.Domain = clusterDomain
 
-	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-api")
-	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-dns")
-	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name + "-ingress")
+	// Add one to the fletcher8 result because 0 is an invalid vrid in
+	// keepalived. This is safe because fletcher8 can never return 255 due to
+	// the modulo arithmetic that happens. The largest value it can return is
+	// 238 (0xEE).
+	node.Cluster.APIVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-api") + 1
+	node.Cluster.DNSVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-dns") + 1
+	if node.Cluster.DNSVirtualRouterID == node.Cluster.APIVirtualRouterID {
+		node.Cluster.DNSVirtualRouterID++
+	}
+	node.Cluster.IngressVirtualRouterID = utils.FletcherChecksum8(node.Cluster.Name+"-ingress") + 1
+	for node.Cluster.IngressVirtualRouterID == node.Cluster.DNSVirtualRouterID || node.Cluster.IngressVirtualRouterID == node.Cluster.APIVirtualRouterID {
+		node.Cluster.IngressVirtualRouterID++
+	}
 
 	if clusterConfigPath != "" {
 		masterAmount, err := getClusterConfigMasterAmount(clusterConfigPath)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,8 +13,8 @@ import (
 func FletcherChecksum8(inp string) uint8 {
 	var ckA, ckB uint8
 	for i := 0; i < len(inp); i++ {
-		ckA = (ckA + inp[i]) & 0xf
-		ckB = (ckB + ckA) & 0xf
+		ckA = (ckA + inp[i]) % 0xf
+		ckB = (ckB + ckA) % 0xf
 	}
 	return (ckB << 4) | ckA
 }


### PR DESCRIPTION
Because the fletcher8 algorithm only has a total of 255 hashes
available, it is highly likely that at some point we will have a
collision between our different VRIDs. This change adds checks for
that situation and increments the ids until they no longer collide.
This should be consistent across all nodes, so they will all end up
using the same ids for the same VIPs.