### PR TITLE
Add support for a provisioning VIP

### DIFF
--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -32,6 +32,10 @@ func main() {
 			if err != nil {
 				dnsVip = nil
 			}
+			apiProvisioningVip, err := cmd.Flags().GetIP("api-provisioning-vip")
+			if err != nil {
+				apiProvisioningVip = nil
+			}
 
 			checkInterval, err := cmd.Flags().GetDuration("check-interval")
 			if err != nil {
@@ -42,7 +46,7 @@ func main() {
 				return err
 			}
 
-			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, dnsVip, checkInterval)
+			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, dnsVip, apiProvisioningVip, checkInterval)
 		},
 	}
 	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
@@ -50,6 +54,7 @@ func main() {
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
 	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	rootCmd.Flags().IP("api-provisioning-vip", nil, "Virtual IP Address to reach Ignition")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}

--- a/cmd/runtimecfg/runtimecfg.go
+++ b/cmd/runtimecfg/runtimecfg.go
@@ -43,6 +43,10 @@ func main() {
 			if err != nil {
 				return err
 			}
+			apiProvisioningVip, err := cmd.Flags().GetIP("api-provisioning-vip")
+			if err != nil {
+				apiProvisioningVip = nil
+			}
 			lbPort, err := cmd.Flags().GetUint16("lb-port")
 			if err != nil {
 				return err
@@ -60,7 +64,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
+			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiProvisioningVip, apiPort, lbPort, statPort)
 			if err != nil {
 				return err
 			}
@@ -96,6 +100,10 @@ func main() {
 			if err != nil {
 				return err
 			}
+			apiProvisioningVip, err := cmd.Flags().GetIP("api-provisioning-vip")
+			if err != nil {
+				apiProvisioningVip = nil
+			}
 			lbPort, err := cmd.Flags().GetUint16("lb-port")
 			if err != nil {
 				return err
@@ -112,7 +120,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
+			config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiProvisioningVip, apiPort, lbPort, statPort)
 			if err != nil {
 				return err
 			}
@@ -139,6 +147,7 @@ func main() {
 	rootCmd.PersistentFlags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
 	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	rootCmd.PersistentFlags().IP("api-provisioning-vip", nil, "Virtual IP Address to reach Ignition")
 	rootCmd.PersistentFlags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	rootCmd.PersistentFlags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
 	rootCmd.PersistentFlags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -14,7 +14,7 @@ import (
 
 const keepalivedControlSock = "/var/run/keepalived/keepalived.sock"
 
-func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip, dnsVip net.IP, interval time.Duration) error {
+func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip, dnsVip net.IP, apiProvisioningVip net.IP, interval time.Duration) error {
 	var prevConfig *config.Node
 
 	signals := make(chan os.Signal, 1)
@@ -38,7 +38,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		case <-done:
 			return nil
 		default:
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVip, ingressVip, dnsVip, 0, 0, 0)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVip, ingressVip, dnsVip, apiProvisioningVip, 0, 0, 0)
 			if err != nil {
 				return err
 			}

--- a/test/data/keepalived.conf.tmpl
+++ b/test/data/keepalived.conf.tmpl
@@ -16,6 +16,12 @@ vrrp_script chk_ingress {
     weight 50
 }
 
+{{if .Cluster.APIProvisioningVIP}}
+vrrp_script chk_api_prov {
+    script "curl -o /dev/null -kLs https://0:2379"
+}
+{{end}}
+
 vrrp_instance {{.Cluster.Name}}_API {
     state BACKUP
     interface {{.VRRPInterface}}
@@ -51,3 +57,23 @@ vrrp_instance {{.Cluster.Name}}_INGRESS {
         chk_ingress
     }
 }
+
+{{if .Cluster.APIProvisioningVIP}}
+vrrp_instance {{.Cluster.Name}}_PROVISION {
+    state BACKUP
+    interface {{ .VRRPProvInterface }}
+    virtual_router_id {{ .Cluster.APIProvisioningVirtualRouterID }}
+    priority 40
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{ .Cluster.Name }}_api_provisioning_vip
+    }
+    virtual_ipaddress {
+        {{ .Cluster.APIProvisioningVIP }}/{{ .Cluster.ProvVIPNetmask }}
+    }
+    track_script {
+        chk_api_prov
+    }
+}
+{{end}}


### PR DESCRIPTION
In some cases it may be necessary to specify a VIP that keepalived will then
listen on in order to provision within some networks. This adds support for
that interface and VIP.