### PR TITLE
Convert /128 addresses to /64

### DIFF
--- a/pkg/config/net.go
+++ b/pkg/config/net.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAddr *net.IPNet, err error) {
@@ -27,6 +28,11 @@ func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAdd
 				if _, ok := vipMap[n.IP.String()]; ok {
 					continue // This is a VIP, let's skip
 				}
+				// FIXME: Breaks if more then one interface on the host has the same prefix
+				// DHCPv6 assigns addresses with a /128 if encountered assume /64
+				// so that the n.Contains returns true if the VIP has the same prefix
+				_, n, _ = net.ParseCIDR(strings.Replace(addr.String(), "/128", "/64", 1))
+
 				if n.Contains(vips[0]) {
 					return iface, n, err
 				}


### PR DESCRIPTION
In order to select an interface for the VIPs we
are trying to find a interface with an IP in the
same subnet.

If using DHCPv6 then addresses have a /128 address,
assume in this case its enough to test if the VIP
is in the same /64.