### PR TITLE
Revert "Convert /128 addresses to /64"

### DIFF
--- a/pkg/config/net.go
+++ b/pkg/config/net.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"net"
-	"strings"
 )
 
 func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAddr *net.IPNet, err error) {
@@ -28,11 +27,6 @@ func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAdd
 				if _, ok := vipMap[n.IP.String()]; ok {
 					continue // This is a VIP, let's skip
 				}
-				// FIXME: Breaks if more then one interface on the host has the same prefix
-				// DHCPv6 assigns addresses with a /128 if encountered assume /64
-				// so that the n.Contains returns true if the VIP has the same prefix
-				_, n, _ = net.ParseCIDR(strings.Replace(addr.String(), "/128", "/64", 1))
-
 				if n.Contains(vips[0]) {
 					return iface, n, err
 				}


### PR DESCRIPTION
This reverts commit 24845d3960ce1dcadac2dfaaac089783ba2aace7.

Passing an ipaddress through net.ParseCIDR ends up stripping
out averything but the network part of the IPaddress.