### PR TITLE
Add support for coredns Corefile watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ network_closure.sh
 runtimecfg
 monitor
 dynkeepalived
+corednsmonitor

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,14 @@ WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor cmd/runtimecfg/runtimecfg.go
 RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
+RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
 RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
 
 ENTRYPOINT ["/usr/bin/runtimecfg"]

--- a/cmd/corednsmonitor/corednsmonitor.go
+++ b/cmd/corednsmonitor/corednsmonitor.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"time"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var log = logrus.New()
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:   "corednsmonitor path_to_kubeconfig path_to_keepalived_cfg_template path_to_config",
+		Short: "Monitors runtime external interface for Coredns Corefile changes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				cmd.Help()
+				return nil
+			}
+			apiVip, err := cmd.Flags().GetIP("api-vip")
+			if err != nil {
+				apiVip = nil
+			}
+			ingressVip, err := cmd.Flags().GetIP("ingress-vip")
+			if err != nil {
+				ingressVip = nil
+			}
+			dnsVip, err := cmd.Flags().GetIP("dns-vip")
+			if err != nil {
+				dnsVip = nil
+			}
+
+			checkInterval, err := cmd.Flags().GetDuration("check-interval")
+			if err != nil {
+				return err
+			}
+			clusterConfigPath, err := cmd.Flags().GetString("cluster-config")
+			if err != nil {
+				return err
+			}
+
+			return monitor.CorednsWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, dnsVip, checkInterval)
+		},
+	}
+	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
+	rootCmd.Flags().Duration("check-interval", time.Second*120, "Time between keepalived watch checks")
+	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Failed due to %s", err)
+	}
+}

--- a/pkg/monitor/corednsmonitor.go
+++ b/pkg/monitor/corednsmonitor.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/config"
+	"github.com/openshift/baremetal-runtimecfg/pkg/render"
+	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+const resolvConfFilepath string = "/var/run/NetworkManager/resolv.conf"
+
+func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip, dnsVip net.IP, interval time.Duration) error {
+	var prevMD5 string
+
+	signals := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+
+	signal.Notify(signals, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGINT)
+	go func() {
+		<-signals
+		done <- true
+	}()
+
+	prevMD5, err := utils.GetFileMd5(resolvConfFilepath)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-done:
+			return nil
+		default:
+			curMD5, err := utils.GetFileMd5(resolvConfFilepath)
+			if err != nil {
+				return err
+			}
+			if curMD5 != prevMD5 {
+				newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, resolvConfFilepath, apiVip, ingressVip, dnsVip, 0, 0, 0)
+				if err != nil {
+					return err
+				}
+				log.WithFields(logrus.Fields{
+					"DNS upstreams": newConfig.DNSUpstreams,
+				}).Info("Resolv.conf change detected, rendering Corefile")
+
+				err = render.RenderFile(cfgPath, templatePath, newConfig)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"config": newConfig,
+					}).Error("Failed to render coredns Corefile")
+					return err
+				}
+				prevMD5 = curMD5
+			}
+			time.Sleep(interval)
+		}
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"crypto/md5"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -95,4 +98,20 @@ func AlarmStabilization(cur_alrm bool, cur_defect bool, consecutive_ctr uint8, o
 		consecutive_ctr = 0
 	}
 	return new_alrm, consecutive_ctr
+}
+
+func GetFileMd5(filePath string) (string, error) {
+	var returnMD5String string
+	file, err := os.Open(filePath)
+	if err != nil {
+		return returnMD5String, err
+	}
+	defer file.Close()
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return returnMD5String, err
+	}
+	hashInBytes := hash.Sum(nil)[:16]
+	returnMD5String = hex.EncodeToString(hashInBytes)
+	return returnMD5String, nil
 }


### PR DESCRIPTION
The runtimecfg render for coredns runs as initcontainer and
is responsible for Corefile composing.
With coredns-monitor it's possible to watch for changes in
NetworkManager resolv.conf file and update Corefile correspondingly.