### PR TITLE
Remove unused utils.GetEtcdSRVMembers() function

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -70,14 +70,6 @@ func EtcdShortHostname() (shortName string, err error) {
 	return etcdHostname, err
 }
 
-func GetEtcdSRVMembers(domain string) (srvs []*net.SRV, err error) {
-	_, srvs, err = net.LookupSRV("etcd-server-ssl", "tcp", domain)
-	if err != nil {
-		return srvs, err
-	}
-	return srvs, err
-}
-
 func GetFirstAddr(host string) (string, error) {
 	addrs, err := net.LookupHost(host)
 	if err != nil {

--- a/test/data/keepalived.conf.tmpl
+++ b/test/data/keepalived.conf.tmpl
@@ -4,12 +4,6 @@ vrrp_script chk_ocp {
     weight 50
 }
 
-vrrp_script chk_dns {
-    script "host -t SRV _etcd-server-ssl._tcp.{{.Cluster.Domain}} localhost"
-    interval 1
-    weight 50
-}
-
 vrrp_script chk_ingress {
     script "curl -o /dev/null -kLs https://0:1936/healthz"
     interval 1


### PR DESCRIPTION
The utils.GetEtcdSRVMembers() is no longer used after
https://github.com/openshift/baremetal-runtimecfg/pull/52/

Also removes the `chk_dns` script from the test keepalived config to
remove all trace of etcd SRV records in baremetal-runtimecfg.