### PR TITLE
Bug 1821720: Move haproxy listening port due to conflict

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -52,7 +52,7 @@ func main() {
 		},
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	rootCmd.Flags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
+	rootCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
 	rootCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -22,7 +22,7 @@ func init() {
 	displayCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	displayCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	displayCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	displayCmd.Flags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
+	displayCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
 	displayCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	displayCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(displayCmd)

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -27,7 +27,7 @@ func init() {
 	renderCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	renderCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	renderCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	renderCmd.Flags().Uint16("lb-port", 7443, "Port where the API HAProxy LB will listen at")
+	renderCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
 	renderCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	renderCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(renderCmd)


### PR DESCRIPTION
The "Recovering from expired control plane certificates" procedure [1]
stands up a recovery API server on port 7443 [2], conflicting with the
port the haproxy process is listening on.

This patch moves the haproxy port to 9443 instead.

[1] https://docs.openshift.com/container-platform/4.3/backup_and_restore/disaster_recovery/scenario-3-expired-certs.html

[2] https://github.com/openshift/cluster-kube-apiserver-operator/blob/3161546a248f20eb67231017d0ae43c245bfa4cb/pkg/recovery/apiserver.go#L307