### PR TITLE
Bug 1823950: Switch to /readyz for haproxy healthchecking

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -91,7 +91,7 @@ func IsKubernetesHealthy(port uint16) (bool, error) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/healthz", port))
+	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/readyz", port))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Per [0], the /readyz endpoint is how the api communicates that it
is gracefully shutting down. Once /readyz starts to report failure,
we want to stop sending traffic to that backend. If we wait for
/healthz, it may be too late because once /healthz starts failing
the api is already not accepting connections.

0: https://github.com/openshift/installer/pull/3537