### PR TITLE
Bug 1840222: Fail if no upstream DNS servers are found

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -230,6 +231,11 @@ func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVip 
 		if upstream != node.NonVirtualIP && upstream != node.Cluster.DNSVIP && upstream != "127.0.0.1" && upstream != "::1" {
 			node.DNSUpstreams = append(node.DNSUpstreams, upstream)
 		}
+	}
+	// If we end up with no upstream DNS servers we'll generate an invalid
+	// coredns config. Error out so the init container retries.
+	if len(node.DNSUpstreams) < 1 {
+		return node, errors.New("No upstream DNS servers found")
 	}
 
 	prefix, _ := nonVipAddr.Mask.Size()


### PR DESCRIPTION
Coredns will fail to start if we configure the forward plugin with
no upstream servers. The init container responsible for rendering
the config needs to fail if that situation arises so it can be
retried later when hopefully resolv.conf has been populated correctly.

We're not sure how it happens that there are no upstream servers,
but it's clearly wrong for us to render an invalid config so this
is the safe thing to do anyway.