### PR TITLE
Add support for unicast keepalived

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ network_closure.sh
 /monitor
 /dynkeepalived
 /corednsmonitor
+/unicastipserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ RUN GO111MODULE=on go build --mod=vendor -o runtimecfg ./cmd/runtimecfg
 RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
 RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
 RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
+RUN GO111MODULE=on go build --mod=vendor cmd/unicastipserver/unicastipserver.go
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/unicastipserver /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
 
 ENTRYPOINT ["/usr/bin/runtimecfg"]

--- a/cmd/unicastipserver/unicastipserver.go
+++ b/cmd/unicastipserver/unicastipserver.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:   "unicastipserver [path to kubeconfig] [api-vip] [dns-vip] [ingress-vip] [api-provisioning-vip]",
+		Short: "baremetal-runtimecfg discovers OpenShift cluster and node configuration and renders Go templates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			apiVip, err := cmd.Flags().GetIP("api-vip")
+			if err != nil {
+				apiVip = nil
+			}
+			ingressVip, err := cmd.Flags().GetIP("ingress-vip")
+			if err != nil {
+				ingressVip = nil
+			}
+			dnsVip, err := cmd.Flags().GetIP("dns-vip")
+			if err != nil {
+				dnsVip = nil
+			}
+			unicastipServerPort, err := cmd.Flags().GetUint16("unicastip-server-port")
+			if err != nil {
+				return err
+			}
+
+			return monitor.UnicastIPServer(apiVip, ingressVip, dnsVip, unicastipServerPort)
+		},
+	}
+
+	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	rootCmd.Flags().Uint16("unicastip-server-port", 64444, "Port where the OpenShift API listens at")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -1,21 +1,102 @@
 package monitor
 
 import (
+	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/baremetal-runtimecfg/pkg/config"
 	"github.com/openshift/baremetal-runtimecfg/pkg/render"
 	"github.com/sirupsen/logrus"
 )
 
 const keepalivedControlSock = "/var/run/keepalived/keepalived.sock"
+const cfgKeepalivedChangeThreshold uint8 = 3
+const dummyPortNum uint16 = 123
+const unicastPatternInCfgFile = "unicast_peer"
+
+var (
+	g_BootstrapIP string
+)
+
+func getEnabledUnicastFromFile(cfgPath string) (error, bool) {
+	enableUnicast := false
+	_, err := os.Stat(cfgPath)
+	if os.IsNotExist(err) {
+		return err, enableUnicast
+	}
+
+	b, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return err, enableUnicast
+	}
+	s := string(b)
+	// //check whether conf file contains unicast config pattern
+	if strings.Contains(s, unicastPatternInCfgFile) {
+		enableUnicast = true
+	}
+	return nil, enableUnicast
+}
+
+func updateUnicastConfig(kubeconfigPath string, newConfig, appliedConfig *config.Node) {
+	var err error
+
+	if !newConfig.EnableUnicast {
+		return
+	}
+	retrieveBootstrapIpAddr(newConfig.Cluster.APIVIP)
+	newConfig.BootstrapIP = g_BootstrapIP
+
+	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath)
+	if err != nil {
+		log.Warnf("Could not retrieve ingress config: %v", err)
+	}
+
+	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, net.ParseIP(newConfig.Cluster.APIVIP))
+	if err != nil {
+		log.Warnf("Could not retrieve LB config: %v", err)
+	}
+}
+
+func doesConfigChanged(curConfig, appliedConfig *config.Node) bool {
+	validConfig := true
+	cfgChanged := appliedConfig == nil || !cmp.Equal(*appliedConfig, *curConfig)
+	// In unicast mode etcd is used for sync purpose between bootstrap and the masters nodes,
+	// we want to apply new config to master nodes only after nodes appears in etcd, with this
+	// approach we should avoid asymetric configuration
+	if curConfig.EnableUnicast {
+		if os.Getenv("IS_BOOTSTRAP") == "no" && len(curConfig.LBConfig.Backends) == 0 {
+			validConfig = false
+		}
+	}
+	return cfgChanged && validConfig
+}
+
+func retrieveBootstrapIpAddr(apiVip string) {
+	var err error
+
+	if g_BootstrapIP != "" {
+		return
+	}
+	// we don't need to read the bootstrap IP address for bootstrap node
+	if os.Getenv("IS_BOOTSTRAP") == "yes" {
+		g_BootstrapIP = ""
+		return
+	}
+	g_BootstrapIP, err = config.GetBootstrapIP(apiVip)
+	if err != nil {
+		log.Warnf("Could not retrieve bootstrap IP: %v", err)
+	}
+}
 
 func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip, dnsVip net.IP, interval time.Duration) error {
-	var prevConfig *config.Node
+	var appliedConfig, curConfig, prevConfig *config.Node
+	var configChangeCtr uint8 = 0
 
 	signals := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
@@ -32,7 +113,6 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		return err
 	}
 	defer conn.Close()
-
 	for {
 		select {
 		case <-done:
@@ -42,25 +122,54 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			if err != nil {
 				return err
 			}
-			if prevConfig == nil || prevConfig.VRRPInterface != newConfig.VRRPInterface {
+			//In upgrade flow, we should first continue with the same mode (unicast or multicast) as currently configured in keepalived.conf file
+			err, enableUnicastFromFile := getEnabledUnicastFromFile(cfgPath)
+			if err == nil && newConfig.EnableUnicast != enableUnicastFromFile {
 				log.WithFields(logrus.Fields{
-					"new config": newConfig,
+					"newConfig.EnableUnicast": newConfig.EnableUnicast,
+					"enableUnicastFromFile":   enableUnicastFromFile,
+				}).Info("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
+				newConfig.EnableUnicast = enableUnicastFromFile
+			}
+			updateUnicastConfig(kubeconfigPath, &newConfig, appliedConfig)
+			curConfig = &newConfig
+			if doesConfigChanged(curConfig, appliedConfig) {
+				if prevConfig == nil || cmp.Equal(*prevConfig, *curConfig) {
+					configChangeCtr++
+				} else {
+					configChangeCtr = 1
+				}
+				log.WithFields(logrus.Fields{
+					"current config":  *curConfig,
+					"configChangeCtr": configChangeCtr,
 				}).Info("Config change detected")
-				err = render.RenderFile(cfgPath, templatePath, newConfig)
-				if err != nil {
-					log.WithFields(logrus.Fields{
-						"config": newConfig,
-					}).Error("Failed to render Keepalived configuration")
-					return err
-				}
 
-				_, err = conn.Write([]byte("reload\n"))
-				if err != nil {
+				if configChangeCtr >= cfgKeepalivedChangeThreshold {
+
 					log.WithFields(logrus.Fields{
-						"socket": keepalivedControlSock,
-					}).Error("Failed to write reload to Keepalived container control socket")
-					return err
+						"curConfig": *curConfig,
+					}).Info("Apply config change")
+
+					err = render.RenderFile(cfgPath, templatePath, newConfig)
+					if err != nil {
+						log.WithFields(logrus.Fields{
+							"config": newConfig,
+						}).Error("Failed to render Keepalived configuration")
+						return err
+					}
+
+					_, err = conn.Write([]byte("reload\n"))
+					if err != nil {
+						log.WithFields(logrus.Fields{
+							"socket": keepalivedControlSock,
+						}).Error("Failed to write reload to Keepalived container control socket")
+						return err
+					}
+					configChangeCtr = 0
+					appliedConfig = curConfig
 				}
+			} else {
+				configChangeCtr = 0
 			}
 			prevConfig = &newConfig
 			time.Sleep(interval)

--- a/pkg/monitor/unicastipserver.go
+++ b/pkg/monitor/unicastipserver.go
@@ -1,0 +1,38 @@
+package monitor
+
+import (
+	"net"
+	"strconv"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/config"
+)
+
+// UnicastIPServer starts a server
+func UnicastIPServer(apiVip, ingressVip, dnsVip net.IP, unicastIPServerPort uint16) error {
+	_, nonVirtualIP, err := config.GetVRRPConfig(apiVip, ingressVip, dnsVip)
+
+	if err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("::", strconv.Itoa(int(unicastIPServerPort))))
+	if err != nil {
+		return err
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		log.Infof("Connection from %v accepted", conn.RemoteAddr().String())
+		go handleConn(conn, nonVirtualIP.IP.String())
+	}
+}
+
+func handleConn(conn net.Conn, nonVirtualIP string) {
+	log.Infof("Writing %v to socket", nonVirtualIP)
+	conn.Write([]byte(nonVirtualIP + "\n"))
+	conn.Close()
+}


### PR DESCRIPTION
With this PR keepalived capability extended to support both unicast and multicast modes.

The following components were updated to support unicast mode:

- A simple server that will return node's non-virtual IP address, this server will be used
  by the master nodes to retrieve the bootstrap node IP address. One should contact the server on port 64444.

- keepalived-monitor can render conf file to support unicast or multicast mode, based on configuration.
