### PR TITLE
Bug 1847086 : Update kube-api health check to use localhost

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -83,7 +83,7 @@ func IsKubernetesHealthy(port uint16) (bool, error) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/healthz", port))
+	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/readyz", port))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
K8s health check should use localhost instead of 127.0.0.1 to support both
IPv6 and IPv4