### PR TITLE
BUG 1853889: Move haproxy port to 9445 due to conflict with KCM

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -52,7 +52,7 @@ func main() {
 		},
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	rootCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
+	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	rootCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -22,7 +22,7 @@ func init() {
 	displayCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	displayCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	displayCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	displayCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
+	displayCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	displayCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	displayCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(displayCmd)

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -27,7 +27,7 @@ func init() {
 	renderCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	renderCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	renderCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	renderCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
+	renderCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	renderCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	renderCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(renderCmd)


### PR DESCRIPTION
HAProxy port was moved on [1] to 9443, this cinflicted with KCM recovery container
which is using 9443 since 4.3. on [2] KCM added a check that the port is free which
caused a conflict and a crashlooping pod.

[1] https://github.com/openshift/baremetal-runtimecfg/pull/59
[2] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/421

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>