### PR TITLE
Bug 1857672: Also copy iptables scripts to /usr/sbin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /u
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/ip*tables /usr/sbin/
 
 ENTRYPOINT ["/usr/bin/runtimecfg"]
 


### PR DESCRIPTION
In recent images there are iptables binaries in /usr/sbin/ in
addition to/in place of /usr/bin. This is causing problems because
/usr/sbin is in the PATH before /usr/bin so our code is calling the
wrong iptables. We can just copy the iptables scripts into /usr/sbin
and take care of the problem.