### PR TITLE
Stream dhclient stderr logs

### DIFF
--- a/pkg/monitor/lease.go
+++ b/pkg/monitor/lease.go
@@ -88,6 +88,7 @@ func leaseVIP(cfgPath, masterDevice, name string) error {
 
 	cmd := exec.Command("dhclient", "-d", "--no-pid", "-sf", "/bin/true",
 		"-lf", getLeaseFile(cfgPath, name), "-v", iface.Name, "-H", name)
+	cmd.Stderr = os.Stderr
 
 	return cmd.Start()
 }


### PR DESCRIPTION
In order to monitor `dhclient` behavior - Channels the command `stderr` stream