### PR TITLE
Change macvlan to be private mode

### DIFF
--- a/pkg/monitor/lease.go
+++ b/pkg/monitor/lease.go
@@ -117,7 +117,7 @@ func leaseInterface(masterDevice string, name string) (*net.Interface, error) {
 
 	mv := &netlink.Macvlan{
 		LinkAttrs: linkAttrs,
-		Mode:      netlink.MACVLAN_MODE_BRIDGE,
+		Mode:      netlink.MACVLAN_MODE_PRIVATE,
 	}
 
 	// Create interface

--- a/pkg/monitor/lease_test.go
+++ b/pkg/monitor/lease_test.go
@@ -91,6 +91,12 @@ var _ = Describe("lease_vip", func() {
 			Expect(testIface.Name).ShouldNot(Equal(realIface.Name))
 			Expect(testIface.HardwareAddr).ShouldNot(Equal(realIface.HardwareAddr))
 
+			link, err := netlink.LinkByName(testIface.Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			macvlan, ok := link.(*netlink.Macvlan)
+			Expect(ok).Should(BeTrue())
+			Expect(macvlan.Mode).Should(Equal(netlink.MACVLAN_MODE_PRIVATE))
+
 			iface, err := net.InterfaceByName(testName)
 			Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
No need to support BRIDGE mode.
Private mode doesn’t allow communication between MACVLAN instances on the same physical interface.