### PR TITLE
Do not override bootstrap IP

### DIFF
--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -67,11 +67,15 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
+	cfg, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, dnsVip, apiPort, lbPort, statPort)
 	if err != nil {
 		return err
 	}
+	lbConf, err := config.GetLBConfig(kubeCfgPath, apiPort, lbPort, statPort, apiVip)
+	if err == nil {
+		cfg.LBConfig = lbConf
+	}
 
-	spew.Dump(config)
+	spew.Dump(cfg)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20190712022805-31fe033ae6f9
 	k8s.io/apimachinery v0.0.0-20190711222657-391ed67afa7b
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -97,11 +97,22 @@ func retrieveBootstrapIpAddr(apiVip string) {
 		gBootstrapIP = ""
 		return
 	}
-	retrievedIP, err := config.GetBootstrapIP(apiVip)
-	if err != nil {
-		log.Debugf("Could not retrieve bootstrap IP: %v", err)
-	} else {
-		gBootstrapIP = retrievedIP
+	if gBootstrapIP != "" {
+		// Test if bootstrap is still up and running
+		retrievedIP, err := config.GetBootstrapIP(gBootstrapIP)
+		if err != nil { // Let's clear the bootstrap, since it is probably gone
+			gBootstrapIP = ""
+			log.Debugf("Bootstrap unicast IP server no longer listening at: %s", gBootstrapIP)
+		}
+		log.Debugf("Bootstrap unicast IP server still listening at: %s", gBootstrapIP)
+	} else { // Get the bootstrap IP
+		retrievedIP, err := config.GetBootstrapIP(apiVip)
+		if err != nil {
+			log.Debugf("Could not retrieve bootstrap IP: %v", err)
+		} else {
+			log.Debugf("Found Bootstrap unicast IP server listening at: %s", retrievedIP)
+			gBootstrapIP = retrievedIP
+		}
 	}
 }
 

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	gBootstrapIP string
+	gBootstrapIP string = ""
 )
 
 func getActualMode(cfgPath string) (error, bool) {
@@ -97,9 +97,11 @@ func retrieveBootstrapIpAddr(apiVip string) {
 		gBootstrapIP = ""
 		return
 	}
-	gBootstrapIP, err = config.GetBootstrapIP(apiVip)
+	retrievedIP, err := config.GetBootstrapIP(apiVip)
 	if err != nil {
 		log.Debugf("Could not retrieve bootstrap IP: %v", err)
+	} else {
+		gBootstrapIP = retrievedIP
 	}
 }
 


### PR DESCRIPTION
Remaining: Decide when to actually remove the bootstrap IP. Probably it
is going to be try to use its unicast server at the old IP and see when
it goes away.