### PR TITLE
Install dhclient instead of dhcp-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN GO111MODULE=on go build --mod=vendor cmd/unicastipserver/unicastipserver.go
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-RUN yum install -y dhcp-client && yum clean all
+RUN yum install -y dhclient && yum clean all
 
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin


### PR DESCRIPTION
dhcp-client is the new name for the dhclient package in RHEL 8.
Since our images are currently still being built with RHEL 7, this
is causing our image builds to fail. Using the old name should work
in both versions, so until the RHEL 8 transition happens let's use
it.

Note that even though the Dockerfile says to use ubi8, that is
ignored in the product image builds.