### PR TITLE
Read BootstrapIP from OCP API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20190712022805-31fe033ae6f9
 	k8s.io/apimachinery v0.0.0-20190711222657-391ed67afa7b
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -58,7 +58,7 @@ func updateUnicastConfig(kubeconfigPath string, newConfig, appliedConfig *config
 	if !newConfig.EnableUnicast {
 		return
 	}
-	retrieveBootstrapIpAddr(newConfig.Cluster.APIVIP)
+	retrieveBootstrapIpAddr(kubeconfigPath)
 	newConfig.BootstrapIP = gBootstrapIP
 
 	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath)
@@ -86,7 +86,7 @@ func doesConfigChanged(curConfig, appliedConfig *config.Node) bool {
 	return cfgChanged && validConfig
 }
 
-func retrieveBootstrapIpAddr(apiVip string) {
+func retrieveBootstrapIpAddr(kubeconfigPath string) {
 	var err error
 
 	if gBootstrapIP != "" {
@@ -97,7 +97,7 @@ func retrieveBootstrapIpAddr(apiVip string) {
 		gBootstrapIP = ""
 		return
 	}
-	gBootstrapIP, err = config.GetBootstrapIP(apiVip)
+	gBootstrapIP, err = config.GetBootstrapIP(kubeconfigPath)
 	if err != nil {
 		log.Debugf("Could not retrieve bootstrap IP: %v", err)
 	}


### PR DESCRIPTION
In unicast Keeplaived, master nodes should register the bootstrap as one of the peers.
With this PR master nodes retrieve the Bootstrap IP address from OCP API instead of
reading it from a dedicated server that runs on the bootstrap node.

A follow-up PRs should delete the unicast server capability in both baremetal-runtimecfg and the MCO.