### PR TITLE
Bug 1862898: Move haproxy port to 9445 due to conflict with KCM

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -52,7 +52,7 @@ func main() {
 		},
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	rootCmd.Flags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
+	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	rootCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")

--- a/cmd/runtimecfg/runtimecfg.go
+++ b/cmd/runtimecfg/runtimecfg.go
@@ -166,7 +166,7 @@ func main() {
 	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
 	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	rootCmd.PersistentFlags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
-	rootCmd.PersistentFlags().Uint16("lb-port", 9443, "Port where the API HAProxy LB will listen at")
+	rootCmd.PersistentFlags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	rootCmd.PersistentFlags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
 	rootCmd.PersistentFlags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 


### PR DESCRIPTION
** cherry pick for [3][4] **

HAProxy port was moved on [1] to 9443, this cinflicted with KCM recovery container
which is using 9443 since 4.3. on [2] KCM added a check that the port is free which
caused a conflict and a crashlooping pod.

[1] https://github.com/openshift/baremetal-runtimecfg/pull/61
[2] openshift/cluster-kube-controller-manager-operator#423
[3]https://github.com/openshift/baremetal-runtimecfg/pull/71
[4]https://github.com/openshift/baremetal-runtimecfg/pull/73

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>