### PR TITLE
Change local Dockerfile to use CentOS 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o runtimecfg ./cmd/runtimecfg
@@ -7,9 +7,9 @@ RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
 RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
 RUN GO111MODULE=on go build --mod=vendor cmd/unicastipserver/unicastipserver.go
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM centos:8
 
-RUN yum install -y dhclient diffutils && yum clean all
+RUN yum install -y dhcp-client diffutils && yum clean all
 
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin


### PR DESCRIPTION
Now that CI and Productization uses Dockerfile.openshift, the "main"
Dockerfile is free to use CentOS 8. This should limit the drift.