### PR TITLE
Read properly information from localhost API when it's needed

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -365,10 +365,10 @@ func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVip 
 
 // getSortedBackends builds config to communicate with kube-api based on kubeconfigPath parameter value, if kubeconfigPath is not empty it will build the
 // config based on that content else config will point to localhost.
-func getSortedBackends(kubeconfigPath string) (backends []Backend, err error) {
+func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool) (backends []Backend, err error) {
 
 	kubeApiServerUrl := ""
-	if kubeconfigPath == "" {
+	if readFromLocalAPI {
 		kubeApiServerUrl = localhostKubeApiServerUrl
 	}
 	config, err := clientcmd.BuildConfigFromFlags(kubeApiServerUrl, kubeconfigPath)
@@ -427,11 +427,11 @@ func GetLBConfig(kubeconfigPath string, apiPort, lbPort, statPort uint16, apiVip
 		config.FrontendAddr = "::"
 	}
 	// Try reading master nodes details first from api-vip:kube-apiserver and failover to localhost:kube-apiserver
-	backends, err := getSortedBackends(kubeconfigPath)
+	backends, err := getSortedBackends(kubeconfigPath, false)
 	if err != nil {
 		log.Infof("An error occurred while trying to read master nodes details from api-vip:kube-apiserver: %v", err)
 		log.Infof("Trying to read master nodes details from localhost:kube-apiserver")
-		backends, err = getSortedBackends("")
+		backends, err = getSortedBackends(kubeconfigPath, true)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"kubeconfigPath": kubeconfigPath,


### PR DESCRIPTION
For Keepalived unicast configuration, we should be able to read nodes details from the localhost:kube-apiserver

With this PR we should be able to read nodes information also from localhost.

How to verify the fix? 

1. ssh into one of the masters
2. Change server value in kubeconfig file 
    a. sudo vi /var/lib/kubelet/kubeconfig
    b. change  **server: https://api-int.ostest.test.metalkube.org:6443** to some dummy server for example
     **server: https://192.168.111.199:6443**
3. Wait for ~60 seconds and check the logs of haproxy-monitor container, we shouldn't see [this error](https://github.com/openshift/baremetal-runtimecfg/blob/master/pkg/monitor/monitor.go#L63)

