### PR TITLE
Change keepalived VIP subnet mask to host mask

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -348,8 +348,11 @@ func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVip 
 		return node, errors.New("No upstream DNS servers found")
 	}
 
-	prefix, _ := nonVipAddr.Mask.Size()
-	node.Cluster.VIPNetmask = prefix
+	if apiVip.To4() == nil {
+		node.Cluster.VIPNetmask = 128
+	} else {
+		node.Cluster.VIPNetmask = 32
+	}
 	node.VRRPInterface = vipIface.Name
 
 	// We can't populate this with GetLBConfig because in many cases the


### PR DESCRIPTION
To work around [1]  bug in network manager the subnet mask of Keepalived VIP address was set to the value of control plane IP subnet mask.
So, after the network manager bug was resolved we can safely change VIP subnet mask to a host subnet mask.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1700415