### PR TITLE
Bug 1885867 :  Flip to unicast only when MCO set to desired version in all nodes

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -234,7 +234,9 @@ func IsUpgradeStillRunning(kubeconfigPath string) (error, bool) {
 	}
 
 	for _, node := range nodes.Items {
-		if node.Annotations["machineconfiguration.openshift.io/desiredConfig"] != node.Annotations["machineconfiguration.openshift.io/currentConfig"] {
+		if node.Annotations["machineconfiguration.openshift.io/desiredConfig"] != node.Annotations["machineconfiguration.openshift.io/currentConfig"] ||
+			node.Annotations["machineconfiguration.openshift.io/desiredConfig"] != nodes.Items[0].Annotations["machineconfiguration.openshift.io/desiredConfig"] {
+
 			return nil, true
 		}
 	}


### PR DESCRIPTION
In 4.5 to 4.6 upgrade we support automatic Keepalived mode flip to unicast,
the change to unicast should start only after MCO finished configuring the 4.6 desired state
in all the nodes.

With this PR the flip mode starts only after all the nodes configured with the new MCO configuration.