### PR TITLE
Bug 1894539: Allow baremetal-runtimecfg to function when the node isn't attached to the VIP network

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -190,7 +190,7 @@ func GetVRRPConfig(apiVip, ingressVip, dnsVip net.IP) (vipIface net.Interface, n
 	if dnsVip != nil {
 		vips = append(vips, dnsVip)
 	}
-	return GetInterfaceAndNonVIPAddr(vips)
+	return getInterfaceAndNonVIPAddr(vips)
 }
 
 func IsUpgradeStillRunning(kubeconfigPath string) (error, bool) {


### PR DESCRIPTION
There are a few problems preventing `baremetal-runtimecfg` to work when the node isn't attached to the VIP network.
- The `render` command complains when the node is not on a subnet on which the VIP is routable.
- The `node-ip` accepts running without providing a VIP, but still complains when we pass it a VIP and the node isn't attached to the subnet including the VIP.

This is a first step to support deploying additional machinesets on separate subnets.