### PR TITLE
Update "runtimecfg node-ip" for dual-stack

### DIFF
--- a/pkg/utils/addresses.go
+++ b/pkg/utils/addresses.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// AddressFilter is a function type to filter addresses
+type AddressFilter func(netlink.Addr) bool
+
+// RouteFilter is a function type to filter routes
+type RouteFilter func(netlink.Route) bool
+
+func getAddrs(filter AddressFilter) (addrMap map[netlink.Link][]netlink.Addr, err error) {
+	nlHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
+	if err != nil {
+		return nil, err
+	}
+	defer nlHandle.Delete()
+
+	links, err := nlHandle.LinkList()
+	if err != nil {
+		return nil, err
+	}
+
+	addrMap = make(map[netlink.Link][]netlink.Addr)
+	for _, link := range links {
+		addresses, err := nlHandle.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, err
+		}
+		for _, address := range addresses {
+			if filter != nil && !filter(address) {
+				log.Debugf("Ignoring filtered address %+v", address)
+				continue
+			}
+
+			if _, ok := addrMap[link]; ok {
+				addrMap[link] = append(addrMap[link], address)
+			} else {
+				addrMap[link] = []netlink.Addr{address}
+			}
+		}
+	}
+	log.Debugf("retrieved Address map %+v", addrMap)
+	return addrMap, nil
+}
+
+func getRouteMap(filter RouteFilter) (routeMap map[int][]netlink.Route, err error) {
+	nlHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
+	if err != nil {
+		return nil, err
+	}
+	defer nlHandle.Delete()
+
+	routes, err := nlHandle.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, err
+	}
+
+	routeMap = make(map[int][]netlink.Route)
+	for _, route := range routes {
+		if filter != nil && !filter(route) {
+			log.Debugf("Ignoring filtered route %+v", route)
+			continue
+		}
+		if _, ok := routeMap[route.LinkIndex]; ok {
+			routeMap[route.LinkIndex] = append(routeMap[route.LinkIndex], route)
+		} else {
+			routeMap[route.LinkIndex] = []netlink.Route{route}
+		}
+	}
+
+	log.Debugf("Retrieved route map %+v", routeMap)
+
+	return routeMap, nil
+}
+
+// ValidNodeAddress returns true if the address is suitable for a node's primary IP
+func ValidNodeAddress(address netlink.Addr) bool {
+	// Ignore link-local addresses
+	if address.IP.IsLinkLocalUnicast() {
+		return false
+	}
+
+	// Ignore deprecated IPv6 addresses
+	if net.IPv6len == len(address.IP) && address.PreferedLft == 0 {
+		return false
+	}
+
+	return true
+}
+
+// usableIPv6Route returns true if the passed route is acceptable for AddressesRouting
+func usableIPv6Route(route netlink.Route) bool {
+	// Ignore default routes
+	if route.Dst == nil {
+		return false
+	}
+	// Ignore non-IPv6 routes
+	if net.IPv6len != len(route.Dst.IP) {
+		return false
+	}
+	// Ignore non-advertised routes
+	if route.Protocol != unix.RTPROT_RA {
+		return false
+	}
+
+	return true
+}
+
+// AddressesRouting takes a slice of Virtual IPs and returns a slice of configured addresses in the current network namespace that directly route to those vips. You can optionally pass an AddressFilter to further filter down which addresses are considered
+func AddressesRouting(vips []net.IP, af AddressFilter) ([]net.IP, error) {
+	addrMap, err := getAddrs(af)
+	if err != nil {
+		return nil, err
+	}
+
+	var routeMap map[int][]netlink.Route
+	matches := make([]net.IP, 0)
+	for link, addresses := range addrMap {
+		for _, address := range addresses {
+			maskPrefix, maskBits := address.Mask.Size()
+			if net.IPv6len == len(address.IP) && maskPrefix == maskBits {
+				if routeMap == nil {
+					routeMap, err = getRouteMap(usableIPv6Route)
+					if err != nil {
+						return nil, err
+					}
+				}
+				if routes, ok := routeMap[link.Attrs().Index]; ok {
+					for _, route := range routes {
+						log.Infof("Checking route %+v (mask %s) for address %+v", route, route.Dst.Mask, address)
+						containmentNet := net.IPNet{IP: address.IP, Mask: route.Dst.Mask}
+						for _, vip := range vips {
+							log.Infof("Checking whether address %s with route %s contains VIP %s", address, route, vip)
+							if containmentNet.Contains(vip) {
+								log.Infof("Address %s with route %s contains VIP %s", address, route, vip)
+								matches = append(matches, address.IP)
+							}
+						}
+					}
+				}
+			} else {
+				for _, vip := range vips {
+					log.Infof("Checking whether address %s contains VIP %s", address, vip)
+					if address.Contains(vip) {
+						log.Infof("Address %s contains VIP %s", address, vip)
+						matches = append(matches, address.IP)
+					}
+				}
+			}
+		}
+
+	}
+	return matches, nil
+}
+
+// defaultRoute returns true if the passed route is a default route
+func defaultRoute(route netlink.Route) bool {
+	return route.Dst == nil
+}
+
+// AddressesDefault and returns a slice of configured addresses in the current network namespace associated with default routes. You can optionally pass an AddressFilter to further filter down which addresses are considered
+func AddressesDefault(af AddressFilter) ([]net.IP, error) {
+	addrMap, err := getAddrs(af)
+	if err != nil {
+		return nil, err
+	}
+	routeMap, err := getRouteMap(defaultRoute)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := make([]net.IP, 0)
+	for link, addresses := range addrMap {
+		if routeMap[link.Attrs().Index] == nil {
+			continue
+		}
+		for _, address := range addresses {
+			log.Infof("Address %s is on interface %s with default route", address, link.Attrs().Name)
+			matches = append(matches, address.IP)
+		}
+	}
+	return matches, nil
+}

--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -1,0 +1,277 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+var lo = &netlink.Device{
+	LinkAttrs: netlink.LinkAttrs{
+		Index: 0,
+		Name:  "lo",
+	},
+}
+var eth0 = &netlink.Device{
+	LinkAttrs: netlink.LinkAttrs{
+		Index: 1,
+		Name:  "eth0",
+	},
+}
+var eth1 = &netlink.Device{
+	LinkAttrs: netlink.LinkAttrs{
+		Index: 2,
+		Name:  "eth1",
+	},
+}
+
+func maybeAddAddress(addrMap map[netlink.Link][]netlink.Addr, af AddressFilter, link netlink.Link, addrStr string, deprecated bool) {
+	addr, err := netlink.ParseAddr(addrStr)
+	if err != nil {
+		panic(fmt.Sprintf("bad address string %q in test case", addrStr))
+	}
+	if !deprecated {
+		addr.PreferedLft = 999
+	}
+	if af != nil && !af(*addr) {
+		return
+	}
+	addrMap[link] = append(addrMap[link], *addr)
+}
+
+func maybeAddRoute(routeMap map[int][]netlink.Route, rf RouteFilter, link netlink.Link, destination string, ra bool) {
+	var dst *net.IPNet
+	var err error
+	if destination != "" {
+		_, dst, err = net.ParseCIDR(destination)
+		if err != nil {
+			panic(fmt.Sprintf("bad route string %q in test case", destination))
+		}
+	}
+	prot := unix.RTPROT_KERNEL
+	if ra {
+		prot = unix.RTPROT_RA
+	}
+	linkIndex := link.Attrs().Index
+	route := netlink.Route{
+		LinkIndex: linkIndex,
+		Dst:       dst,
+		Protocol:  prot,
+	}
+	if rf != nil && !rf(route) {
+		return
+	}
+	routeMap[linkIndex] = append(routeMap[linkIndex], route)
+}
+
+func addIPv4Addrs(addrs map[netlink.Link][]netlink.Addr, af AddressFilter) {
+	maybeAddAddress(addrs, af, lo, "127.0.0.1/8", false)
+	maybeAddAddress(addrs, af, lo, "::1/128", false)
+	maybeAddAddress(addrs, af, eth0, "10.0.0.5/24", false)
+	maybeAddAddress(addrs, af, eth0, "169.254.10.10/16", false)
+	maybeAddAddress(addrs, af, eth0, "10.0.0.100/24", false)
+	maybeAddAddress(addrs, af, eth1, "192.168.1.2/24", false)
+}
+
+func addIPv4Routes(routes map[int][]netlink.Route, rf RouteFilter) {
+	maybeAddRoute(routes, rf, eth0, "", false)
+	maybeAddRoute(routes, rf, eth0, "10.0.0.0/24", false)
+	maybeAddRoute(routes, rf, eth1, "192.168.1.0/24", false)
+}
+
+func addIPv4RoutesDefaultEth1(routes map[int][]netlink.Route, rf RouteFilter) {
+	maybeAddRoute(routes, rf, eth0, "10.0.0.0/24", false)
+	maybeAddRoute(routes, rf, eth1, "", false)
+	maybeAddRoute(routes, rf, eth1, "192.168.1.0/24", false)
+}
+
+func addIPv6Addrs(addrs map[netlink.Link][]netlink.Addr, af AddressFilter) {
+	maybeAddAddress(addrs, af, lo, "127.0.0.1/8", false)
+	maybeAddAddress(addrs, af, lo, "::1/128", false)
+	maybeAddAddress(addrs, af, eth0, "fd00::5/64", false)
+	maybeAddAddress(addrs, af, eth0, "fe80::1234/64", false)
+	maybeAddAddress(addrs, af, eth1, "fd01::3/64", true)
+	maybeAddAddress(addrs, af, eth1, "fd01::4/64", true)
+	maybeAddAddress(addrs, af, eth1, "fd01::5/64", false)
+}
+
+func addIPv6Routes(routes map[int][]netlink.Route, rf RouteFilter) {
+	maybeAddRoute(routes, rf, eth0, "", false)
+	maybeAddRoute(routes, rf, eth0, "fd00::/64", false)
+	maybeAddRoute(routes, rf, eth0, "fd02::/64", false)
+	maybeAddRoute(routes, rf, eth1, "fd01::/64", false)
+}
+
+func ipv4AddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
+	addrs := make(map[netlink.Link][]netlink.Addr)
+	addIPv4Addrs(addrs, af)
+	return addrs, nil
+}
+
+func ipv4RouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addIPv4Routes(routes, rf)
+	return routes, nil
+}
+
+func ipv4RouteMapDefaultEth1(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addIPv4RoutesDefaultEth1(routes, rf)
+	return routes, nil
+}
+
+func ipv6AddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
+	addrs := make(map[netlink.Link][]netlink.Addr)
+	addIPv6Addrs(addrs, af)
+	return addrs, nil
+}
+
+func ipv6RouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addIPv6Routes(routes, rf)
+	return routes, nil
+}
+
+func dualStackAddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
+	addrs := make(map[netlink.Link][]netlink.Addr)
+	addIPv4Addrs(addrs, af)
+	addIPv6Addrs(addrs, af)
+	return addrs, nil
+}
+
+func dualStackRouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addIPv4Routes(routes, rf)
+	addIPv6Routes(routes, rf)
+	return routes, nil
+}
+
+var _ = Describe("addresses", func() {
+	It("matches an IPv4 VIP on the primary interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("10.0.0.2")},
+			ValidNodeAddress,
+			ipv4AddrMap,
+			ipv4RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+	})
+
+	It("matches an IPv4 VIP on the secondary interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("192.168.1.99")},
+			ValidNodeAddress,
+			ipv4AddrMap,
+			ipv4RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("192.168.1.2")}))
+	})
+
+	It("matches an IPv4 VIP when the default route is on another interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("10.0.0.2")},
+			ValidNodeAddress,
+			ipv4AddrMap,
+			ipv4RouteMapDefaultEth1,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+	})
+
+	It("matches an IPv6 VIP on the primary interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd00::2")},
+			ValidNodeAddress,
+			ipv6AddrMap,
+			ipv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5")}))
+	})
+
+	It("matches an IPv6 VIP on an interface with temporary IPs", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd01::2")},
+			ValidNodeAddress,
+			ipv6AddrMap,
+			ipv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5")}))
+	})
+
+	It("matches an IPv4 VIP on a dual-stack interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("10.0.0.2")},
+			ValidNodeAddress,
+			dualStackAddrMap,
+			dualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+	})
+
+	It("matches an IPv6 VIP on a dual-stack interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd01::2")},
+			ValidNodeAddress,
+			dualStackAddrMap,
+			dualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5")}))
+	})
+
+	It("finds an interface with a default route in an IPv4 cluster", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			ipv4AddrMap,
+			ipv4RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+	})
+
+	It("finds an interface with a default route when that's not the first interface", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			ipv4AddrMap,
+			ipv4RouteMapDefaultEth1,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("192.168.1.2")}))
+	})
+
+	It("finds an interface with a default route in an IPv6 cluster", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			ipv6AddrMap,
+			ipv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5")}))
+	})
+
+	It("finds an interface with a default route in a dual-stack cluster", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			dualStackAddrMap,
+			dualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100"), net.ParseIP("fd00::5")}))
+	})
+})
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Addresses tests")
+}

--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -161,7 +161,7 @@ var _ = Describe("addresses", func() {
 			ipv4RouteMap,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5")}))
 	})
 
 	It("matches an IPv4 VIP on the secondary interface", func() {
@@ -183,7 +183,7 @@ var _ = Describe("addresses", func() {
 			ipv4RouteMapDefaultEth1,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5")}))
 	})
 
 	It("matches an IPv6 VIP on the primary interface", func() {
@@ -216,7 +216,7 @@ var _ = Describe("addresses", func() {
 			dualStackRouteMap,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::5")}))
 	})
 
 	It("matches an IPv6 VIP on a dual-stack interface", func() {
@@ -227,7 +227,7 @@ var _ = Describe("addresses", func() {
 			dualStackRouteMap,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5"), net.ParseIP("192.168.1.2")}))
 	})
 
 	It("finds an interface with a default route in an IPv4 cluster", func() {
@@ -237,7 +237,7 @@ var _ = Describe("addresses", func() {
 			ipv4RouteMap,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5")}))
 	})
 
 	It("finds an interface with a default route when that's not the first interface", func() {
@@ -267,7 +267,7 @@ var _ = Describe("addresses", func() {
 			dualStackRouteMap,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("10.0.0.100"), net.ParseIP("fd00::5")}))
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::5")}))
 	})
 })
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,14 +7,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
 var log = logrus.New()
@@ -68,14 +65,6 @@ func EtcdShortHostname() (shortName string, err error) {
 	}
 	etcdHostname := strings.Replace(shortHostname, "master", "etcd", 1)
 	return etcdHostname, err
-}
-
-func GetFirstAddr(host string) (string, error) {
-	addrs, err := net.LookupHost(host)
-	if err != nil {
-		return "", err
-	}
-	return addrs[0], nil
 }
 
 func IsKubernetesHealthy(port uint16) (bool, error) {
@@ -132,184 +121,4 @@ func GetFileMd5(filePath string) (string, error) {
 	hashInBytes := hash.Sum(nil)[:16]
 	returnMD5String = hex.EncodeToString(hashInBytes)
 	return returnMD5String, nil
-}
-
-// AddressFilter is a function type to filter addresses
-type AddressFilter func(netlink.Addr) bool
-
-// RouteFilter is a function type to filter routes
-type RouteFilter func(netlink.Route) bool
-
-func getAddrs(filter AddressFilter) (addrMap map[netlink.Link][]netlink.Addr, err error) {
-	nlHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
-	if err != nil {
-		return nil, err
-	}
-	defer nlHandle.Delete()
-
-	links, err := nlHandle.LinkList()
-	if err != nil {
-		return nil, err
-	}
-
-	addrMap = make(map[netlink.Link][]netlink.Addr)
-	for _, link := range links {
-		addresses, err := nlHandle.AddrList(link, netlink.FAMILY_ALL)
-		if err != nil {
-			return nil, err
-		}
-		for _, address := range addresses {
-			if filter != nil && !filter(address) {
-				log.Debugf("Ignoring filtered address %+v", address)
-				continue
-			}
-
-			if _, ok := addrMap[link]; ok {
-				addrMap[link] = append(addrMap[link], address)
-			} else {
-				addrMap[link] = []netlink.Addr{address}
-			}
-		}
-	}
-	log.Debugf("retrieved Address map %+v", addrMap)
-	return addrMap, nil
-}
-
-func getRouteMap(filter RouteFilter) (routeMap map[int][]netlink.Route, err error) {
-	nlHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
-	if err != nil {
-		return nil, err
-	}
-	defer nlHandle.Delete()
-
-	routes, err := nlHandle.RouteList(nil, netlink.FAMILY_ALL)
-	if err != nil {
-		return nil, err
-	}
-
-	routeMap = make(map[int][]netlink.Route)
-	for _, route := range routes {
-		if filter != nil && !filter(route) {
-			log.Debugf("Ignoring filtered route %+v", route)
-			continue
-		}
-		if _, ok := routeMap[route.LinkIndex]; ok {
-			routeMap[route.LinkIndex] = append(routeMap[route.LinkIndex], route)
-		} else {
-			routeMap[route.LinkIndex] = []netlink.Route{route}
-		}
-	}
-
-	log.Debugf("Retrieved route map %+v", routeMap)
-
-	return routeMap, nil
-}
-
-// ValidNodeAddress returns true if the address is suitable for a node's primary IP
-func ValidNodeAddress(address netlink.Addr) bool {
-	// Ignore link-local addresses
-	if address.IP.IsLinkLocalUnicast() {
-		return false
-	}
-
-	// Ignore deprecated IPv6 addresses
-	if net.IPv6len == len(address.IP) && address.PreferedLft == 0 {
-		return false
-	}
-
-	return true
-}
-
-// usableIPv6Route returns true if the passed route is acceptable for AddressesRouting
-func usableIPv6Route(route netlink.Route) bool {
-	// Ignore default routes
-	if route.Dst == nil {
-		return false
-	}
-	// Ignore non-IPv6 routes
-	if net.IPv6len != len(route.Dst.IP) {
-		return false
-	}
-	// Ignore non-advertised routes
-	if route.Protocol != unix.RTPROT_RA {
-		return false
-	}
-
-	return true
-}
-
-// AddressesRouting takes a slice of Virtual IPs and returns a slice of configured addresses in the current network namespace that directly route to those vips. You can optionally pass an AddressFilter to further filter down which addresses are considered
-func AddressesRouting(vips []net.IP, af AddressFilter) ([]net.IP, error) {
-	addrMap, err := getAddrs(af)
-	if err != nil {
-		return nil, err
-	}
-
-	var routeMap map[int][]netlink.Route
-	matches := make([]net.IP, 0)
-	for link, addresses := range addrMap {
-		for _, address := range addresses {
-			maskPrefix, maskBits := address.Mask.Size()
-			if net.IPv6len == len(address.IP) && maskPrefix == maskBits {
-				if routeMap == nil {
-					routeMap, err = getRouteMap(usableIPv6Route)
-					if err != nil {
-						return nil, err
-					}
-				}
-				if routes, ok := routeMap[link.Attrs().Index]; ok {
-					for _, route := range routes {
-						log.Infof("Checking route %+v (mask %s) for address %+v", route, route.Dst.Mask, address)
-						containmentNet := net.IPNet{IP: address.IP, Mask: route.Dst.Mask}
-						for _, vip := range vips {
-							log.Infof("Checking whether address %s with route %s contains VIP %s", address, route, vip)
-							if containmentNet.Contains(vip) {
-								log.Infof("Address %s with route %s contains VIP %s", address, route, vip)
-								matches = append(matches, address.IP)
-							}
-						}
-					}
-				}
-			} else {
-				for _, vip := range vips {
-					log.Infof("Checking whether address %s contains VIP %s", address, vip)
-					if address.Contains(vip) {
-						log.Infof("Address %s contains VIP %s", address, vip)
-						matches = append(matches, address.IP)
-					}
-				}
-			}
-		}
-
-	}
-	return matches, nil
-}
-
-// defaultRoute returns true if the passed route is a default route
-func defaultRoute(route netlink.Route) bool {
-	return route.Dst == nil
-}
-
-// AddressesDefault and returns a slice of configured addresses in the current network namespace associated with default routes. You can optionally pass an AddressFilter to further filter down which addresses are considered
-func AddressesDefault(af AddressFilter) ([]net.IP, error) {
-	addrMap, err := getAddrs(af)
-	if err != nil {
-		return nil, err
-	}
-	routeMap, err := getRouteMap(defaultRoute)
-	if err != nil {
-		return nil, err
-	}
-
-	matches := make([]net.IP, 0)
-	for link, addresses := range addrMap {
-		if routeMap[link.Attrs().Index] == nil {
-			continue
-		}
-		for _, address := range addresses {
-			log.Infof("Address %s is on interface %s with default route", address, link.Attrs().Name)
-			matches = append(matches, address.IP)
-		}
-	}
-	return matches, nil
 }


### PR DESCRIPTION
In kube 1.20 you can pass two IPs to `kubelet --node-ip`, but we still need help from runtimecfg to find the _right_ IPs.

First commit is just a reorg, second commit adds unit tests without changing functionality, and then the third commit changes the utils functions to return dual-stack answers and changes runtimecfg to make use of it. (Previously the utils functions returned multiple IPs of the same family but the caller only ever used the first value, so this just changes it to return only that first value, plus a second value of the opposite family.)

(I still need to write the corresponding MCO change and test it all...)