### PR TITLE
Bug 1894539: Allow node-ip to function without attachment to VIP network

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -144,7 +144,8 @@ func getSuitableIPs(retry bool, vips []net.IP) (chosen []net.IP, err error) {
 			if len(chosen) > 0 || err != nil {
 				return chosen, err
 			}
-		} else {
+		}
+		if len(chosen) == 0 {
 			chosen, err = utils.AddressesDefault(utils.ValidNodeAddress)
 			if len(chosen) > 0 || err != nil {
 				return chosen, err


### PR DESCRIPTION
Fall back to IP addresses associated with the default route in the when
the node is not on a subnet containing any of the VIPs.

Restore the feature implemented in
384c50336098baf83cb66c823cf142408d5ba8cf and broken with 83d05afd1b76b8f0078887f1001e722284235a3a.