### PR TITLE
Bug 1905233:  get the correct VRRP interface in case of IPV6 overlapping subnets

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -138,6 +138,8 @@ func set(cmd *cobra.Command, args []string) error {
 }
 
 func getSuitableIPs(retry bool, vips []net.IP) (chosen []net.IP, err error) {
+	// Enable debug logging in utils package
+	utils.SetDebugLogLevel()
 	for {
 		if len(vips) > 0 {
 			chosen, err = utils.AddressesRouting(vips, utils.ValidNodeAddress)

--- a/pkg/utils/addresses.go
+++ b/pkg/utils/addresses.go
@@ -144,12 +144,12 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 				}
 				if routes, ok := routeMap[link.Attrs().Index]; ok {
 					for _, route := range routes {
-						log.Infof("Checking route %+v (mask %s) for address %+v", route, route.Dst.Mask, address)
+						log.Debugf("Checking route %+v (mask %s) for address %+v", route, route.Dst.Mask, address)
 						containmentNet := net.IPNet{IP: address.IP, Mask: route.Dst.Mask}
 						for _, vip := range vips {
-							log.Infof("Checking whether address %s with route %s contains VIP %s", address, route, vip)
+							log.Debugf("Checking whether address %s with route %s contains VIP %s", address, route, vip)
 							if containmentNet.Contains(vip) {
-								log.Infof("Address %s with route %s contains VIP %s", address, route, vip)
+								log.Debugf("Address %s with route %s contains VIP %s", address, route, vip)
 								matches = append(matches, address.IP)
 								break addrLoop
 							}
@@ -158,9 +158,9 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 				}
 			} else {
 				for _, vip := range vips {
-					log.Infof("Checking whether address %s contains VIP %s", address, vip)
+					log.Debugf("Checking whether address %s contains VIP %s", address, vip)
 					if address.Contains(vip) {
-						log.Infof("Address %s contains VIP %s", address, vip)
+						log.Debugf("Address %s contains VIP %s", address, vip)
 						matches = append(matches, address.IP)
 						break addrLoop
 					}
@@ -212,7 +212,7 @@ func addressesDefaultInternal(af AddressFilter, getAddrs addressMapFunc, getRout
 				continue
 			}
 
-			log.Infof("Address %s is on interface %s with default route", address, link.Attrs().Name)
+			log.Debugf("Address %s is on interface %s with default route", address, link.Attrs().Name)
 			matches = append(matches, address.IP)
 		}
 	}

--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -108,6 +108,23 @@ func addIPv6Routes(routes map[int][]netlink.Route, rf RouteFilter) {
 	maybeAddRoute(routes, rf, eth1, "fd01::/64", false)
 }
 
+func addOverlappingIPv6Addrs(addrs map[netlink.Link][]netlink.Addr, af AddressFilter) {
+	maybeAddAddress(addrs, af, lo, "127.0.0.1/8", false)
+	maybeAddAddress(addrs, af, lo, "::1/128", false)
+	maybeAddAddress(addrs, af, eth0, "fd00::f05/120", false)
+	maybeAddAddress(addrs, af, eth0, "fe80::1234/64", false)
+	maybeAddAddress(addrs, af, eth1, "fd00::3/120", true)
+	maybeAddAddress(addrs, af, eth1, "fd00::4/120", true)
+	maybeAddAddress(addrs, af, eth1, "fd00::5/120", false)
+}
+
+func addOverlappingIPv6Routes(routes map[int][]netlink.Route, rf RouteFilter) {
+	maybeAddRoute(routes, rf, eth0, "", false)
+	maybeAddRoute(routes, rf, eth0, "fd00::f00/120", false)
+	maybeAddRoute(routes, rf, eth0, "fd00::e00/120", false)
+	maybeAddRoute(routes, rf, eth1, "fd00::/120", false)
+}
+
 func ipv4AddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
 	addrs := make(map[netlink.Link][]netlink.Addr)
 	addIPv4Addrs(addrs, af)
@@ -149,6 +166,32 @@ func dualStackRouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
 	routes := make(map[int][]netlink.Route)
 	addIPv4Routes(routes, rf)
 	addIPv6Routes(routes, rf)
+	return routes, nil
+}
+
+func overlappingIpv6AddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
+	addrs := make(map[netlink.Link][]netlink.Addr)
+	addOverlappingIPv6Addrs(addrs, af)
+	return addrs, nil
+}
+
+func overlappingIpv6RouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addOverlappingIPv6Routes(routes, rf)
+	return routes, nil
+}
+
+func overlappingDualStackAddrMap(af AddressFilter) (map[netlink.Link][]netlink.Addr, error) {
+	addrs := make(map[netlink.Link][]netlink.Addr)
+	addIPv4Addrs(addrs, af)
+	addOverlappingIPv6Addrs(addrs, af)
+	return addrs, nil
+}
+
+func overlappingDualStackRouteMap(rf RouteFilter) (map[int][]netlink.Route, error) {
+	routes := make(map[int][]netlink.Route)
+	addIPv4Routes(routes, rf)
+	addOverlappingIPv6Routes(routes, rf)
 	return routes, nil
 }
 
@@ -268,6 +311,70 @@ var _ = Describe("addresses", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::5")}))
+	})
+
+	It("overlapping IPV6 subnets: matches an IPv6 VIP on the primary interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd00::f02")},
+			ValidNodeAddress,
+			overlappingIpv6AddrMap,
+			overlappingIpv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::f05")}))
+	})
+
+	It("overlapping IPV6 subnets: matches an IPv6 VIP on an interface with temporary IPs", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd00::2")},
+			ValidNodeAddress,
+			overlappingIpv6AddrMap,
+			overlappingIpv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5")}))
+	})
+
+	It("overlapping IPV6 subnets: matches an IPv4 VIP on a dual-stack interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("10.0.0.2")},
+			ValidNodeAddress,
+			overlappingDualStackAddrMap,
+			overlappingDualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::f05")}))
+	})
+
+	It("overlapping IPV6 subnets: matches an IPv6 VIP on a dual-stack interface", func() {
+		addrs, err := addressesRoutingInternal(
+			[]net.IP{net.ParseIP("fd00::2")},
+			ValidNodeAddress,
+			overlappingDualStackAddrMap,
+			overlappingDualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5"), net.ParseIP("192.168.1.2")}))
+	})
+
+	It("overlapping IPV6 subnets: finds an interface with a default route in an IPv6 cluster", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			overlappingIpv6AddrMap,
+			overlappingIpv6RouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::f05")}))
+	})
+
+	It("overlapping IPV6 subnets: finds an interface with a default route in a dual-stack cluster", func() {
+		addrs, err := addressesDefaultInternal(
+			ValidNodeAddress,
+			overlappingDualStackAddrMap,
+			overlappingDualStackRouteMap,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::f05")}))
 	})
 })
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,6 +16,10 @@ import (
 
 var log = logrus.New()
 
+func SetDebugLogLevel() {
+	log.SetLevel(logrus.DebugLevel)
+}
+
 func FletcherChecksum8(inp string) uint8 {
 	var ckA, ckB uint8
 	for i := 0; i < len(inp); i++ {


### PR DESCRIPTION
Since DHCPv6 assigns addresses with a /128, only the first 64 bits are considered when the VIP address is compared with the interface address, see [1].  
Comparing only the first 64 bits of the candidate address with the VIP address might lead for choosing the wrong interface in case of overlapping subnets , see [2] as an example .

To handle the overlapping IPV6 subnets case, we should also verify that the candidate address and VIP are L2 connected.

[1] https://github.com/openshift/baremetal-runtimecfg/blob/master/pkg/config/net.go#L39-#L41

[2]
2 interfaces:
Interface A subnet: 1001:db8::/120 , Interface B subnet: 1001:db8::f00/120
VIP address 1001:db8::64
