### PR TITLE
Bug 1915080: add CloseIdleConnections for HTTP K8S API healthcheck

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -80,6 +80,7 @@ func IsKubernetesHealthy(port uint16) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer client.CloseIdleConnections()
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
We noticed a linearly growing number of TCP connections in HAProxy in all clusters,
that are caused by periodic K8S API health check calls by the haproxy-monitor.
This PR verifies that unneeded HTTP connections used for checking API health being closed.