### PR TITLE
Add dnsmasqmonitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN GO111MODULE=on go build --mod=vendor -o runtimecfg ./cmd/runtimecfg
 RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
 RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
 RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
+RUN GO111MODULE=on go build --mod=vendor cmd/dnsmasqmonitor/dnsmasqmonitor.go
 
 FROM centos:8
 
@@ -14,6 +15,7 @@ COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dnsmasqmonitor /usr/bin
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/ip*tables /usr/sbin/
 

--- a/cmd/dnsmasqmonitor/dnsmasqmonitor.go
+++ b/cmd/dnsmasqmonitor/dnsmasqmonitor.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"time"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var log = logrus.New()
+
+func main() {
+	var rootCmd = &cobra.Command{
+		Use:   "dnsmasqmonitor path_to_kubeconfig path_to_host_file_cfg_template path_to_config",
+		Short: "Monitors dnsmasq host configmap",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				cmd.Help()
+				return nil
+			}
+			apiVip, err := cmd.Flags().GetIP("api-vip")
+			if err != nil {
+				apiVip = nil
+			}
+
+			checkInterval, err := cmd.Flags().GetDuration("check-interval")
+			if err != nil {
+				return err
+			}
+
+			return monitor.DnsmasqWatch(args[0], args[1], args[2], apiVip, checkInterval)
+		},
+	}
+	rootCmd.Flags().Duration("check-interval", time.Second*30, "Time between coredns watch checks")
+	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalf("Failed due to %s", err)
+	}
+}

--- a/pkg/monitor/dnsmasqmonitor.go
+++ b/pkg/monitor/dnsmasqmonitor.go
@@ -1,0 +1,86 @@
+package monitor
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/config"
+	"github.com/openshift/baremetal-runtimecfg/pkg/render"
+	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVip net.IP, interval time.Duration) error {
+	signals := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	prevMD5 := ""
+
+	signal.Notify(signals, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGINT)
+	go func() {
+		<-signals
+		done <- true
+	}()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		default:
+			// We only care about the api vip and cluster domain here
+			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVip, apiVip, apiVip, 0, 0, 0)
+			if err != nil {
+				return err
+			}
+			tmpFile, err := ioutil.TempFile("", "")
+			if err != nil {
+				return err
+			}
+			defer os.Remove(tmpFile.Name())
+			err = render.RenderFile(tmpFile.Name(), templatePath, config)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"config":  config,
+					"tmpFile": tmpFile.Name(),
+				}).Error("Failed to render dnsmasq host file")
+				return err
+			}
+			newMD5, err := utils.GetFileMd5(tmpFile.Name())
+			if err != nil {
+				return err
+			}
+			log.WithFields(logrus.Fields{
+				"prevMD5": prevMD5,
+				"newMD5":  newMD5,
+			}).Info("Md5s")
+			if prevMD5 != newMD5 {
+				err = render.RenderFile(cfgPath, templatePath, config)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"config":  config,
+						"tmpFile": tmpFile.Name(),
+					}).Error("Failed to render dnsmasq host file")
+					return err
+				}
+				prevMD5 = newMD5
+				err = ReloadDnsmasq()
+				if err != nil {
+					log.Error("Failed to reload dnsmasq configuration")
+					return err
+				}
+				log.Info("Reloaded dnsmasq")
+			}
+			time.Sleep(interval)
+		}
+	}
+}
+
+func ReloadDnsmasq() error {
+	cmd := exec.Command("dbus-send", "--system", "--dest=uk.org.thekelleys.dnsmasq", "/uk/org/thekelleys/dnsmasq", "uk.org.thekelleys.ClearCache")
+	return cmd.Run()
+}


### PR DESCRIPTION
This is for a simple monitor container that will simply watch the
cluster-hosted-net-services-operator configmap and update the api-int
record in dnsmasq appropriately. If it detects that the content of
the file has changed, it will overwrite the existing api-int.host
file and send the ClearCache dbus command to dnsmasq to reload its
configuration.