### PR TITLE
Build all commands at once in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
-RUN GO111MODULE=on go build --mod=vendor -o runtimecfg ./cmd/runtimecfg
-RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
-RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
-RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
-RUN GO111MODULE=on go build --mod=vendor cmd/dnsmasqmonitor/dnsmasqmonitor.go
+RUN mkdir build
+RUN GO111MODULE=on go build --mod=vendor -o build ./cmd/...
 
 FROM centos:8
 
 RUN yum install -y dhcp-client diffutils && yum clean all
 
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dnsmasqmonitor /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/build/* /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/ip*tables /usr/sbin/
 

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,19 +1,14 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
-RUN GO111MODULE=on go build --mod=vendor -o runtimecfg ./cmd/runtimecfg
-RUN GO111MODULE=on go build --mod=vendor cmd/dynkeepalived/dynkeepalived.go
-RUN GO111MODULE=on go build --mod=vendor cmd/corednsmonitor/corednsmonitor.go
-RUN GO111MODULE=on go build --mod=vendor cmd/monitor/monitor.go
+RUN mkdir build
+RUN GO111MODULE=on go build --mod=vendor -o build ./cmd/...
 
 FROM registry.ci.openshift.org/ocp/4.8:base
 
 RUN yum install -y dhclient diffutils && yum clean all
 
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/runtimecfg /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/monitor /usr/bin
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/dynkeepalived /usr/bin
-COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/corednsmonitor /usr/bin
+COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/build/* /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/* /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/baremetal-runtimecfg/scripts/ip*tables /usr/sbin/
 


### PR DESCRIPTION
This reduces image build time by about half (1:38 vs 3:13 in my local
env) because we don't have to create so many layers.