### PR TITLE
Keepalived - don't configure empty peers list on bootstrap

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -38,6 +38,8 @@ const (
 	started APIState = iota
 )
 
+var BootstrapPeersListConfiguredOnce bool = false
+
 func getActualMode(cfgPath string) (error, bool) {
 	enableUnicast := false
 	_, err := os.Stat(cfgPath)
@@ -83,6 +85,14 @@ func doesConfigChanged(curConfig, appliedConfig *config.Node) bool {
 	if curConfig.EnableUnicast {
 		if os.Getenv("IS_BOOTSTRAP") == "no" && len(curConfig.LBConfig.Backends) == 0 {
 			validConfig = false
+		}
+		if os.Getenv("IS_BOOTSTRAP") == "yes" {
+			if len(curConfig.LBConfig.Backends) > 0 {
+				BootstrapPeersListConfiguredOnce = true
+			}
+			if BootstrapPeersListConfiguredOnce && len(curConfig.LBConfig.Backends) == 0 {
+				validConfig = false
+			}
 		}
 	}
 	return cfgChanged && validConfig


### PR DESCRIPTION
We should run the following steps for Keepalived on bootstrap:
1. Configure empty peers list ( bootstrap should hold the VIP first)
2. After masters registered to cluster , add masters to peers list 
3. Stop Keepalived when local kube-apiserver stop running 

We shouldn't allow configuring empty peers list after step 2 (it will cause 2 separate VRRP  domains --> two nodes may hold the VIP simultaneously ) 
