### PR TITLE
Bug 1957708:  Keepalived- verify that unicast peers list isn't empty on master nodes

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -81,7 +81,7 @@ func doesConfigChanged(curConfig, appliedConfig *config.Node) bool {
 	// we want to apply new config to master nodes only after nodes appears in etcd, with this
 	// approach we should avoid asymetric configuration
 	if curConfig.EnableUnicast {
-		if os.Getenv("IS_BOOTSTRAP") == "no" && len(curConfig.LBConfig.Backends) == 0 {
+		if os.Getenv("IS_BOOTSTRAP") == "no" && len(curConfig.LBConfig.Backends) < 2 {
 			validConfig = false
 		}
 	}


### PR DESCRIPTION
Empty unicast peers list on Keepalived config on one of the master nodes is an invalid use case (that may cause to two nodes hold the VIP).

Monitor container code should verify that generated keepalive config file doesn't include empty unicast peers list, this is [the current code](https://github.com/openshift/baremetal-runtimecfg/blob/master/pkg/monitor/dynkeepalived.go#L84) that verify this case.

But in case only a single master node (for example master-1) was registered to cluster we'll end up with empty unicast peers list in master-1 keepalived conf ( check - https://github.com/openshift/machine-config-operator/blob/master/templates/master/00-master/on-prem/files/keepalived-keepalived.yaml#L54-#L60 ) .

This fix should verify that unicast peers list isn't empty 
