### PR TITLE
Bug 1960716: Log the output of render operations

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -1,10 +1,12 @@
 package render
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -48,6 +50,21 @@ func RenderFile(renderPath, templatePath string, cfg interface{}) error {
 			"path": renderPath,
 		}).Error("Failed to set permissions on file")
 		return err
+	}
+
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, cfg)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"path": renderPath,
+		}).Error("Failed to render template")
+		return err
+	}
+	// The string we get back is a single line with \n's. For readability,
+	// split it and write it line-by-line.
+	lines := strings.Split(buf.String(), "\n")
+	for _, line := range lines {
+		log.Info(line)
 	}
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
When debugging problems related to services whose config files are
rendered by baremetal-runtimecfg, it can be helpful to see exactly
what was rendered. This change adds log output of the full config
as generated by the templating process.