### PR TITLE
Bug 1886572: Calculate keepalived priority for ingress

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -329,7 +329,6 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				newConfig.EnableUnicast = false
 			}
 			updateUnicastConfig(kubeconfigPath, &newConfig, appliedConfig)
-
 			log.WithFields(logrus.Fields{
 				"curConfig": newConfig,
 			}).Info("Mode Update config change")
@@ -375,6 +374,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				newConfig.EnableUnicast = curEnableUnicast
 			}
 			updateUnicastConfig(kubeconfigPath, &newConfig, appliedConfig)
+			newConfig.IngressConfig.Priority = config.GetIngressPriority(kubeconfigPath, newConfig.NonVirtualIP)
 			curConfig = &newConfig
 			if doesConfigChanged(curConfig, appliedConfig) {
 				if prevConfig == nil || cmp.Equal(*prevConfig, *curConfig) {


### PR DESCRIPTION
    Ingress VIP should be set only on a node that runs an instance of the default ingress controller pod.
    In current code, in case extra ingress-controllers are created the ingress VIP might be wrongly set on a node that doesn't run
    an instance of the default ingress controller.
    
    This PR calculates the priority for keepalived ingress VIP depending on the presence of the router pod in the node by monitoring the content of router-internal-default endpoints resource.
