### PR TITLE
Bug 1998951: retrieve only single type  addresses for Keepalived ingress

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -218,7 +218,7 @@ func IsUpgradeStillRunning(kubeconfigPath string) (error, bool) {
 	return nil, false
 }
 
-func GetIngressConfig(kubeconfigPath string) (ingressConfig IngressConfig, err error) {
+func GetIngressConfig(kubeconfigPath string, filterIpType string) (ingressConfig IngressConfig, err error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return ingressConfig, err
@@ -237,6 +237,12 @@ func GetIngressConfig(kubeconfigPath string) (ingressConfig IngressConfig, err e
 	for _, node := range nodes.Items {
 		for _, address := range node.Status.Addresses {
 			if address.Type == v1.NodeInternalIP {
+				if filterIpType != "" {
+					if (net.ParseIP(filterIpType).To4() != nil && net.ParseIP(address.Address).To4() == nil) ||
+						(net.ParseIP(filterIpType).To4() == nil && net.ParseIP(address.Address).To4() != nil) {
+						continue
+					}
+				}
 				ingressConfig.Peers = append(ingressConfig.Peers, address.Address)
 			}
 		}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -64,7 +64,7 @@ func updateUnicastConfig(kubeconfigPath string, newConfig, appliedConfig *config
 	if !newConfig.EnableUnicast {
 		return
 	}
-	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath)
+	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath, newConfig.Cluster.APIVIP)
 	if err != nil {
 		log.Warnf("Could not retrieve ingress config: %v", err)
 	}
@@ -135,7 +135,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	first that it's operational. */
 	log.Info("handleBootstrapStopKeepalived: verify first that local kube-apiserver is operational")
 	for start := time.Now(); time.Since(start) < time.Second*30; {
-		if _, err := config.GetIngressConfig(kubeconfigPath); err == nil {
+		if _, err := config.GetIngressConfig(kubeconfigPath, ""); err == nil {
 			log.Info("handleBootstrapStopKeepalived: local kube-apiserver is operational")
 			break
 		}
@@ -144,7 +144,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	}
 
 	for {
-		if _, err := config.GetIngressConfig(kubeconfigPath); err != nil {
+		if _, err := config.GetIngressConfig(kubeconfigPath, ""); err != nil {
 			// We have started to talk to Ironic through the API VIP as well,
 			// so if Ironic is still up then we need to keep the VIP, even if
 			// the apiserver has gone down.


### PR DESCRIPTION
In case of dual-stack deployment, configure unicast_peer of ingress
VRRP instance with single type (v4/v6) IPs