### PR TITLE
Bug 2012780: Avoid dynamically allocated port range for haproxy

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -53,7 +53,7 @@ func main() {
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens")
 	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen")
-	rootCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen")
+	rootCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -23,7 +23,7 @@ func init() {
 	displayCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	displayCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	displayCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
-	displayCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
+	displayCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen at")
 	displayCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(displayCmd)
 }

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -28,7 +28,7 @@ func init() {
 	renderCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	renderCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	renderCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
-	renderCmd.Flags().Uint16("stat-port", 50000, "Port where the HAProxy stats API will listen at")
+	renderCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen at")
 	renderCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(renderCmd)
 }


### PR DESCRIPTION
The haproxy stats and health endpoints were configured with high
port numbers (50000 and 50936) that conflict with the range used for
dynamic allocation of ports:

$ cat /proc/sys/net/ipv4/ip_local_port_range
32768   60999

This can occasionally cause haproxy to fail if the kernel happens to
pick one of those ports for a client connection.

To avoid this, we should use ports outside the range shown above.
This patch changes the stats endpoint to 30000, while the health
endpoint is controlled by the MCO config and will be fixed in a
separate commit there.