### PR TITLE
Bug 2021544: Ignore VIPs in node-ip show

### DIFF
--- a/pkg/utils/addresses.go
+++ b/pkg/utils/addresses.go
@@ -135,6 +135,16 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 	for link, addresses := range addrMap {
 	addrLoop:
 		for _, address := range addresses {
+			isVip := false
+			for _, vip := range vips {
+				if address.IP.String() == vip.String() {
+					log.Debugf("Address %s is VIP %s. Skipping.", address, vip)
+					isVip = true
+				}
+			}
+			if isVip {
+				continue
+			}
 			maskPrefix, maskBits := address.Mask.Size()
 			if net.IPv6len == len(address.IP) && maskPrefix == maskBits {
 				if routeMap == nil {


### PR DESCRIPTION
Currently the logic in node-ip show allows a VIP to be selected as
the node IP. This is incorrect, although it doesn't generally cause
a problem today because it appears the VIP is ordered after the
correct node IP in the list. However, we shouldn't rely on that
ordering to ensure we pick the correct address.

Note that this was discovered due to a misconfiguration in a cluster
where the VIP was placed on a node that had an address in a different
subnet. In this case, the node IP didn't match so the VIP was
subsequently checked and found to match (because of course it does).
This caused the VIP to be selected as the node IP, which is also an
error. While this scenario is invalid, it does show that it is
possible for the VIP to be selected as a node IP and we should not
allow that.

This patch checks each address in addressesRoutingInternal
against the VIP list and skips processing if it matches a VIP. This
should ensure we never select a VIP as a node IP.