### PR TITLE
Bug 2022050: Add delay after sending bootstrap stop and start messages

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -316,6 +316,9 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				}).Error("Failed to write command to Keepalived container control socket")
 				time.Sleep(1 * time.Second)
 			}
+			// Make sure we don't send multiple messages in close succession if the
+			// bootstrapStopKeepalived queue has more than one item in it.
+			time.Sleep(5 * time.Second)
 
 		case desiredModeInfo := <-updateModeCh:
 


### PR DESCRIPTION
In some environments we seem to be hitting an edge case where more
than one message backs up on the bootstrapStopKeepalived queue,
which means it is possible for a stop and reload message to be sent
back to back. It appears that the stop function on the keepalived
side takes longer, and as a result reload completes before stop
and it sends a SIGHUP to a process that's about to be killed instead
of restarting keepalived like we want.

This patch adds a 5 second delay after a stop or reload message is
sent so keepalived should have plenty of time to process it before
another message comes in.