### PR TITLE
Fix docker_test run

### DIFF
--- a/Dockerfile.unittest
+++ b/Dockerfile.unittest
@@ -1,3 +1,3 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+FROM registry.ci.openshift.org/openshift/release:golang-1.12
 
 RUN yum install -y dhclient && yum clean all

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - dhcp
 
   dhcpd:
-    image: quay.io/cloudctl/dhcp:ubi
+    image: quay.io/cloudctl/dhcp:minimal
     cap_add:
       - NET_ADMIN
     volumes:


### PR DESCRIPTION
The `docker_test` target was failing because of some outdated image references. This PR fixes it so `make docker_test` can run again