### PR TITLE
Get cluster name and base domain from api server

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -21,7 +21,7 @@ func main() {
 				cmd.Help()
 				return nil
 			}
-			clusterName, clusterDomain, err := config.GetKubeconfigClusterNameAndDomain(args[0])
+			clusterName, clusterDomain, err := config.GetClusterNameAndDomainFromAPIServer(args[0])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently we extract the cluster name and cluster domain from the kubeconfig file (on the cluster nodes). This is done by splitting the server url by `.`: https://github.com/openshift/baremetal-runtimecfg/blob/92ec13e1d0daf6eb644cfe25271f341e1fce78ff/pkg/config/node.go#L111-L127

As [BZ 1971709](https://bugzilla.redhat.com/show_bug.cgi?id=1971709) shows this can lead to problems, if the cluster name itself contains a dot. This PR addresses this and gets the cluster name and cluster domain from the `cluster-config-v1` config map, which contains the install-config and the cluster name and cluster domain.