### PR TITLE
Bug 2000236: Disable printing usage help on error

### DIFF
--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -13,8 +13,9 @@ var log = logrus.New()
 
 func main() {
 	var rootCmd = &cobra.Command{
-		Use:   "dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config",
-		Short: "Monitors runtime external interface for keepalived and reloads if it changes",
+		Use:          "dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config",
+		Short:        "Monitors runtime external interface for keepalived and reloads if it changes",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
 				cmd.Help()


### PR DESCRIPTION
When an error of any type happens in dynkeepalived, the usage help message is output. This implies that there was a problem with the options passed to the CLI, but in most cases that is not the case. This unnecessary output also tends to hide the actual error message.
This PR addresses it and silences usage when an error occurs:

```
$ go run ./cmd/dynkeepalived/dynkeepalived.go test/data/kubeconfig /tmp /tmp
INFO[0000] Monitor conf file doesn't exist               file=/unsupported-monitor.conf
Error: dial unix /var/run/keepalived/keepalived.sock: connect: no such file or directory
FATA[0000] Failed due to dial unix /var/run/keepalived/keepalived.sock: connect: no such file or directory 
exit status 1
```

Missing parameter still shows the usage:
```
$ go run ./cmd/dynkeepalived/dynkeepalived.go test/data/kubeconfig /tmp                                                                                                  
Monitors runtime external interface for keepalived and reloads if it changes

Usage:
  dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config [flags]

Flags:
      --api-port uint16           Port where the OpenShift API listens (default 6443)
      --api-vip ip                Virtual IP Address to reach the OpenShift API
      --check-interval duration   Time between keepalived watch checks (default 10s)
  -c, --cluster-config string     Path to cluster-config ConfigMap to retrieve ControlPlane info
      --dns-vip ip                Virtual IP Address to reach an OpenShift node resolving DNS server
  -h, --help                      help for dynkeepalived
      --ingress-vip ip            Virtual IP Address to reach the OpenShift Ingress Routers
      --lb-port uint16            Port where the API HAProxy LB will listen (default 9445)
```