### PR TITLE
Dockerfile: migrate repo to CentOS 8 Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN mkdir build
 RUN GO111MODULE=on go build --mod=vendor -o build ./cmd/...
 
-FROM centos:8
+FROM centos:stream8
 
 RUN yum install -y dhcp-client diffutils && yum clean all
 


### PR DESCRIPTION
Avoid errors related to appstream repo.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>