### PR TITLE
Bug 2069740: Avoid kubernetes node port range

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -53,7 +53,7 @@ func main() {
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens")
 	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen")
-	rootCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen")
+	rootCmd.Flags().Uint16("stat-port", 29445, "Port where the HAProxy stats API will listen")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
 	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -23,7 +23,7 @@ func init() {
 	displayCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	displayCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	displayCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
-	displayCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen at")
+	displayCmd.Flags().Uint16("stat-port", 29445, "Port where the HAProxy stats API will listen at")
 	displayCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(displayCmd)
 }

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -28,7 +28,7 @@ func init() {
 	renderCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
 	renderCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	renderCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
-	renderCmd.Flags().Uint16("stat-port", 30000, "Port where the HAProxy stats API will listen at")
+	renderCmd.Flags().Uint16("stat-port", 29445, "Port where the HAProxy stats API will listen at")
 	renderCmd.Flags().StringP("resolvconf-path", "r", "/etc/resolv.conf", "Optional path to a resolv.conf file to use to get upstream DNS servers")
 	rootCmd.AddCommand(renderCmd)
 }


### PR DESCRIPTION
Per [0], the range 30000-32767 is used for kubernetes node ports.
We should not have haproxy listening in that range to avoid possible
conflicts.

0: https://github.com/openshift/openshift-docs/blob/main/modules/installation-network-user-infra.adoc