### PR TITLE
RFE-2962: Set interface name from node-ip-configuration to configure-ovs

### DIFF
--- a/pkg/config/net.go
+++ b/pkg/config/net.go
@@ -41,7 +41,7 @@ func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAdd
 					// To make sure that the correct interface being chosen for cases like:
 					// 2 interfaces , subnetA: 1001:db8::/120 , subnetB: 1001:db8::f00/120 and VIP address  1001:db8::64
 					nodeAddrs, err := utils.AddressesRouting(vips, utils.ValidNodeAddress)
-					if err == nil && len(nodeAddrs) > 0 && n.IP.Equal(nodeAddrs[0]) {
+					if err == nil && len(nodeAddrs) > 0 && n.IP.Equal(nodeAddrs[0].Address) {
 						return iface, n, nil
 					}
 				}
@@ -66,7 +66,7 @@ func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAdd
 		for _, addr := range addrs {
 			switch n := addr.(type) {
 			case *net.IPNet:
-				if n.IP.String() == nodeAddrs[0].String() {
+				if n.IP.String() == nodeAddrs[0].Address.String() {
 					return iface, n, nil
 				}
 			default:


### PR DESCRIPTION
node-ip-configuration will set env file for configure-ovs when it will
set kubelet ip, this will allow to configure ovs with the bridge on the
same interface that kubelet will use

unitests were not fixed, will do it if we decide this idea is good to go

https://github.com/openshift/machine-config-operator/pull/3222