### PR TITLE
Add note about removing compatibility code

### DIFF
--- a/cmd/corednsmonitor/corednsmonitor.go
+++ b/cmd/corednsmonitor/corednsmonitor.go
@@ -28,6 +28,8 @@ func main() {
 			if err != nil {
 				apiVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(apiVips) < 1 && apiVip != nil {
 				apiVips = []net.IP{apiVip}
 			}
@@ -39,6 +41,8 @@ func main() {
 			if err != nil {
 				ingressVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(ingressVips) < 1 && ingressVip != nil {
 				ingressVips = []net.IP{ingressVip}
 			}

--- a/cmd/corednsmonitor/corednsmonitor.go
+++ b/cmd/corednsmonitor/corednsmonitor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"time"
 
 	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
@@ -23,9 +24,23 @@ func main() {
 			if err != nil {
 				apiVip = nil
 			}
+			apiVips, err := cmd.Flags().GetIPSlice("api-vips")
+			if err != nil {
+				apiVips = []net.IP{}
+			}
+			if len(apiVips) < 1 && apiVip != nil {
+				apiVips = []net.IP{apiVip}
+			}
 			ingressVip, err := cmd.Flags().GetIP("ingress-vip")
 			if err != nil {
 				ingressVip = nil
+			}
+			ingressVips, err := cmd.Flags().GetIPSlice("ingress-vips")
+			if err != nil {
+				ingressVips = []net.IP{}
+			}
+			if len(ingressVips) < 1 && ingressVip != nil {
+				ingressVips = []net.IP{ingressVip}
 			}
 
 			checkInterval, err := cmd.Flags().GetDuration("check-interval")
@@ -37,13 +52,15 @@ func main() {
 				return err
 			}
 
-			return monitor.CorednsWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, checkInterval)
+			return monitor.CorednsWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, checkInterval)
 		},
 	}
 	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
 	rootCmd.Flags().Duration("check-interval", time.Second*30, "Time between coredns watch checks")
-	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
-	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.Flags().IP("api-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
+	rootCmd.Flags().IP("ingress-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.Flags().IPSlice("ingress-vips", nil, "Virtual IP Addresses to reach the OpenShift Ingress Routers")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}

--- a/cmd/dnsmasqmonitor/dnsmasqmonitor.go
+++ b/cmd/dnsmasqmonitor/dnsmasqmonitor.go
@@ -28,6 +28,8 @@ func main() {
 			if err != nil {
 				apiVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(apiVips) < 1 && apiVip != nil {
 				apiVips = []net.IP{apiVip}
 			}

--- a/cmd/dnsmasqmonitor/dnsmasqmonitor.go
+++ b/cmd/dnsmasqmonitor/dnsmasqmonitor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"time"
 
 	"github.com/openshift/baremetal-runtimecfg/pkg/monitor"
@@ -23,17 +24,25 @@ func main() {
 			if err != nil {
 				apiVip = nil
 			}
+			apiVips, err := cmd.Flags().GetIPSlice("api-vips")
+			if err != nil {
+				apiVips = []net.IP{}
+			}
+			if len(apiVips) < 1 && apiVip != nil {
+				apiVips = []net.IP{apiVip}
+			}
 
 			checkInterval, err := cmd.Flags().GetDuration("check-interval")
 			if err != nil {
 				return err
 			}
 
-			return monitor.DnsmasqWatch(args[0], args[1], args[2], apiVip, checkInterval)
+			return monitor.DnsmasqWatch(args[0], args[1], args[2], apiVips, checkInterval)
 		},
 	}
 	rootCmd.Flags().Duration("check-interval", time.Second*30, "Time between coredns watch checks")
-	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IP("api-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}

--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -47,7 +47,7 @@ func main() {
 			// format that the rest of the code now expects.
 			if len(ingressVips) < 1 && ingressVip != nil {
 				ingressVips = []net.IP{ingressVip}
-	}
+			}
 			apiPort, err := cmd.Flags().GetUint16("api-port")
 			if err != nil {
 				return err

--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -30,6 +30,8 @@ func main() {
 			if err != nil {
 				apiVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(apiVips) < 1 && apiVip != nil {
 				apiVips = []net.IP{apiVip}
 			}
@@ -41,6 +43,8 @@ func main() {
 			if err != nil {
 				ingressVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(ingressVips) < 1 && ingressVip != nil {
 				ingressVips = []net.IP{ingressVip}
 	}

--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -25,10 +26,24 @@ func main() {
 			if err != nil {
 				apiVip = nil
 			}
+			apiVips, err := cmd.Flags().GetIPSlice("api-vips")
+			if err != nil {
+				apiVips = []net.IP{}
+			}
+			if len(apiVips) < 1 && apiVip != nil {
+				apiVips = []net.IP{apiVip}
+			}
 			ingressVip, err := cmd.Flags().GetIP("ingress-vip")
 			if err != nil {
 				ingressVip = nil
 			}
+			ingressVips, err := cmd.Flags().GetIPSlice("ingress-vips")
+			if err != nil {
+				ingressVips = []net.IP{}
+			}
+			if len(ingressVips) < 1 && ingressVip != nil {
+				ingressVips = []net.IP{ingressVip}
+	}
 			apiPort, err := cmd.Flags().GetUint16("api-port")
 			if err != nil {
 				return err
@@ -47,14 +62,16 @@ func main() {
 				return err
 			}
 
-			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVip, ingressVip, apiPort, lbPort, checkInterval)
+			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, apiPort, lbPort, checkInterval)
 		},
 	}
 	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
 	rootCmd.Flags().Duration("check-interval", time.Second*10, "Time between keepalived watch checks")
-	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
-	rootCmd.PersistentFlags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
-	rootCmd.PersistentFlags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	rootCmd.Flags().IP("api-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
+	rootCmd.Flags().IP("ingress-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift Ingress Routers")
+	rootCmd.Flags().IPSlice("ingress-vips", nil, "Virtual IP Addresses to reach the OpenShift Ingress Routers")
+	rootCmd.PersistentFlags().IP("dns-vip", nil, "DEPRECATED: Virtual IP Address to reach an OpenShift node resolving DNS server")
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens")
 	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen")
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -53,9 +53,12 @@ func main() {
 			if err != nil {
 				apiVips = []net.IP{}
 			}
+			// If we were passed a VIP using the old interface, coerce it into the list
+			// format that the rest of the code now expects.
 			if len(apiVips) < 1 && apiVip != nil {
 				apiVips = []net.IP{apiVip}
 			}
+			// The monitor takes strings, not net.IPs
 			apiVipStrings := []string{}
 			for _, vip := range apiVips {
 				apiVipStrings = append(apiVipStrings, vip.String())

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -46,16 +47,28 @@ func main() {
 
 			apiVip, err := cmd.Flags().GetIP("api-vip")
 			if err != nil {
-				return err
+				apiVip = nil
 			}
-			return monitor.Monitor(args[0], clusterName, clusterDomain, args[1], args[2], apiVip.String(), apiPort, lbPort, statPort, checkInterval)
+			apiVips, err := cmd.Flags().GetIPSlice("api-vips")
+			if err != nil {
+				apiVips = []net.IP{}
+			}
+			if len(apiVips) < 1 && apiVip != nil {
+				apiVips = []net.IP{apiVip}
+			}
+			apiVipStrings := []string{}
+			for _, vip := range apiVips {
+				apiVipStrings = append(apiVipStrings, vip.String())
+			}
+			return monitor.Monitor(args[0], clusterName, clusterDomain, args[1], args[2], apiVipStrings, apiPort, lbPort, statPort, checkInterval)
 		},
 	}
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens")
 	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen")
 	rootCmd.Flags().Uint16("stat-port", 29445, "Port where the HAProxy stats API will listen")
 	rootCmd.Flags().Duration("check-interval", time.Second*6, "Time between monitor checks")
-	rootCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IP("api-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift API")
+	rootCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -45,6 +45,8 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		apiVips = []net.IP{}
 	}
+	// If we were passed a VIP using the old interface, coerce it into the list
+	// format that the rest of the code now expects.
 	if len(apiVips) < 1 && apiVip != nil {
 		apiVips = []net.IP{apiVip}
 	}
@@ -56,6 +58,8 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		ingressVips = []net.IP{}
 	}
+	// If we were passed a VIP using the old interface, coerce it into the list
+	// format that the rest of the code now expects.
 	if len(ingressVips) < 1 && ingressVip != nil {
 		ingressVips = []net.IP{ingressVip}
 	}

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -4,6 +4,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/openshift/baremetal-runtimecfg/pkg/config"
 	"github.com/spf13/cobra"
+	"net"
 )
 
 var (
@@ -18,9 +19,11 @@ var (
 func init() {
 	displayCmd.Flags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
 	displayCmd.Flags().Bool("verbose", false, "Display extra information about the rendering")
-	displayCmd.Flags().IP("api-vip", nil, "Virtual IP Address to reach the OpenShift API")
-	displayCmd.Flags().IP("ingress-vip", nil, "Virtual IP Address to reach the OpenShift Ingress Routers")
-	displayCmd.Flags().IP("dns-vip", nil, "Virtual IP Address to reach an OpenShift node resolving DNS server")
+	displayCmd.Flags().IP("api-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift API")
+	displayCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
+	displayCmd.Flags().IP("ingress-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift Ingress Routers")
+	displayCmd.Flags().IPSlice("ingress-vips", nil, "Virtual IP Addresses to reach the OpenShift Ingress Routers")
+	displayCmd.Flags().IP("dns-vip", nil, "DEPRECATED: Virtual IP Address to reach an OpenShift node resolving DNS server")
 	displayCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens at")
 	displayCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen at")
 	displayCmd.Flags().Uint16("stat-port", 29445, "Port where the HAProxy stats API will listen at")
@@ -38,9 +41,23 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		apiVip = nil
 	}
+	apiVips, err := cmd.Flags().GetIPSlice("api-vips")
+	if err != nil {
+		apiVips = []net.IP{}
+	}
+	if len(apiVips) < 1 && apiVip != nil {
+		apiVips = []net.IP{apiVip}
+	}
 	ingressVip, err := cmd.Flags().GetIP("ingress-vip")
 	if err != nil {
 		ingressVip = nil
+	}
+	ingressVips, err := cmd.Flags().GetIPSlice("ingress-vips")
+	if err != nil {
+		ingressVips = []net.IP{}
+	}
+	if len(ingressVips) < 1 && ingressVip != nil {
+		ingressVips = []net.IP{ingressVip}
 	}
 	apiPort, err := cmd.Flags().GetUint16("api-port")
 	if err != nil {
@@ -63,7 +80,7 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVip, ingressVip, apiPort, lbPort, statPort)
+	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort)
 	if err != nil {
 		return err
 	}

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -52,6 +52,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 	}
 	// If we were passed a VIP using the old interface, coerce it into the list
 	// format that the rest of the code now expects.
+	// This can be removed when the deprecated single VIP interface goes away
 	if len(apiVips) < 1 && apiVip != nil {
 		apiVips = []net.IP{apiVip}
 	}
@@ -65,6 +66,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 	}
 	// If we were passed a VIP using the old interface, coerce it into the list
 	// format that the rest of the code now expects.
+	// This can be removed when the deprecated single VIP interface goes away
 	if len(ingressVips) < 1 && ingressVip != nil {
 		ingressVips = []net.IP{ingressVip}
 	}

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -50,6 +50,8 @@ func runRender(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		apiVips = []net.IP{}
 	}
+	// If we were passed a VIP using the old interface, coerce it into the list
+	// format that the rest of the code now expects.
 	if len(apiVips) < 1 && apiVip != nil {
 		apiVips = []net.IP{apiVip}
 	}
@@ -61,6 +63,8 @@ func runRender(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		ingressVips = []net.IP{}
 	}
+	// If we were passed a VIP using the old interface, coerce it into the list
+	// format that the rest of the code now expects.
 	if len(ingressVips) < 1 && ingressVip != nil {
 		ingressVips = []net.IP{ingressVip}
 	}

--- a/pkg/config/net.go
+++ b/pkg/config/net.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
 )
 
+// NOTE(bnemec): All addresses in the vips array must be the same ip version
 func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAddr *net.IPNet, err error) {
 	if len(vips) < 1 {
 		return vipIface, nonVipAddr, fmt.Errorf("At least one VIP needs to be fed to this function")

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -326,6 +326,18 @@ func GetIngressConfig(kubeconfigPath string, filterIpType string) (ingressConfig
 	return ingressConfig, nil
 }
 
+// Returns a Node object populated with the configuration specified by the parameters
+// to the function.
+// kubeconfigPath: The path to a kubeconfig that can be used to read cluster status
+// from the k8s api.
+// clusterConfigPath: The path to cluster-config.yaml. This is only available on the
+// bootstrap node so it is optional. If the file is not available, set this to "".
+// resolvConfPath: The path to resolv.conf. Typically either /etc/resolv.conf or
+// /var/run/NetworkManager/resolv.conf.
+// apiVips and ingressVips: Lists of VIPs for API and Ingress, respectively.
+// apiPort: The port on which the k8s api listens. Should be 6443.
+// lbPort: The port on which haproxy listens.
+// statPort: The port on which the haproxy stats endpoint listens.
 func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVips, ingressVips []net.IP, apiPort, lbPort, statPort uint16) (node Node, err error) {
 	vipCount := 0
 	if len(apiVips) > len(ingressVips) {

--- a/pkg/monitor/corednsmonitor.go
+++ b/pkg/monitor/corednsmonitor.go
@@ -16,7 +16,7 @@ import (
 
 const resolvConfFilepath string = "/var/run/NetworkManager/resolv.conf"
 
-func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVip, ingressVip net.IP, interval time.Duration) error {
+func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVips, ingressVips []net.IP, interval time.Duration) error {
 	signals := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
 
@@ -42,7 +42,7 @@ func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath strin
 			if err != nil {
 				return err
 			}
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, resolvConfFilepath, apiVip, ingressVip, 0, 0, 0)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, resolvConfFilepath, apiVips, ingressVips, 0, 0, 0)
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/dnsmasqmonitor.go
+++ b/pkg/monitor/dnsmasqmonitor.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVip net.IP, interval time.Duration) error {
+func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVips []net.IP, interval time.Duration) error {
 	signals := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
 	prevMD5 := ""
@@ -33,7 +33,7 @@ func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVip net.IP, i
 			return nil
 		default:
 			// We only care about the api vip and cluster domain here
-			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVip, apiVip, 0, 0, 0)
+			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVips, apiVips, 0, 0, 0)
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -1,7 +1,7 @@
 package monitor
 
 import (
-	//"fmt"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -58,7 +58,7 @@ func getActualMode(cfgPath string) (error, bool) {
 	return nil, enableUnicast
 }
 
-func updateUnicastConfig(kubeconfigPath string, newConfig, appliedConfig *config.Node) {
+func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node) {
 	var err error
 
 	if !newConfig.EnableUnicast {
@@ -72,6 +72,17 @@ func updateUnicastConfig(kubeconfigPath string, newConfig, appliedConfig *config
 	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, net.ParseIP(newConfig.Cluster.APIVIP))
 	if err != nil {
 		log.Warnf("Could not retrieve LB config: %v", err)
+	}
+
+	for _, c := range *newConfig.Configs {
+		c.IngressConfig, err = config.GetIngressConfig(kubeconfigPath, c.Cluster.APIVIP)
+		if err != nil {
+			log.Warnf("Could not retrieve ingress config: %v", err)
+		}
+		c.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, net.ParseIP(c.Cluster.APIVIP))
+		if err != nil {
+			log.Warnf("Could not retrieve LB config: %v", err)
+		}
 	}
 }
 
@@ -218,41 +229,54 @@ func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh 
 }
 
 func handleLeasing(cfgPath string, apiVips, ingressVips []net.IP) error {
-// 	vips, err := getVipsToLease(cfgPath)
-//
-// 	if err != nil {
-// 		return err
-// 	}
-//
-// 	if vips == nil {
-// 		return nil
-// 	}
-//
-// 	if vips.APIVip.IpAddress != apiVip.String() {
-// 		return fmt.Errorf("Mismatched ip for api. Expected: %s Actual: %s", apiVip.String(), vips.APIVip.IpAddress)
-// 	}
-//
-// 	if vips.IngressVip.IpAddress != ingressVip.String() {
-// 		return fmt.Errorf("Mismatched ip for ingress. Expected: %s Actual: %s", ingressVip.String(), vips.IngressVip.IpAddress)
-// 	}
-//
-// 	vipIface, _, err := config.GetVRRPConfig(apiVip, ingressVip)
-// 	if err != nil {
-// 		return err
-// 	}
-//
-// 	if err = LeaseVIPs(log, cfgPath, vipIface.Name, []vip{*vips.APIVip, *vips.IngressVip}); err != nil {
-// 		log.WithFields(logrus.Fields{
-// 			"cfgPath":        cfgPath,
-// 			"vipMasterIface": vipIface.Name,
-// 			"vips":           []vip{*vips.APIVip, *vips.IngressVip},
-// 		}).WithError(err).Error("Failed to lease VIPS")
-// 		return err
-// 	}
-//
-// 	log.WithFields(logrus.Fields{
-// 		"cfgPath": cfgPath,
-// 	}).Info("Leased VIPS successfully")
+	vips, err := getVipsToLease(cfgPath)
+
+	if err != nil {
+		return err
+	}
+
+	if vips == nil {
+		return nil
+	}
+
+	if len(apiVips) != len(vips.APIVips) {
+		return fmt.Errorf("Mismatched number of API VIPs. Expected: %d Actual: %d", len(apiVips), len(vips.APIVips))
+	}
+	if len(ingressVips) != len(vips.IngressVips) {
+		return fmt.Errorf("Mismatched number of Ingress VIPs. Expected: %d Actual: %d", len(ingressVips), len(vips.IngressVips))
+	}
+
+	for i, vip := range vips.APIVips {
+		if vip.IpAddress != apiVips[i].String() {
+			return fmt.Errorf("Mismatched ip for api. Expected: %s Actual: %s", apiVips[i].String(), vips.APIVip.IpAddress)
+		}
+	}
+
+	for i, vip := range vips.IngressVips {
+		if vip.IpAddress != ingressVips[i].String() {
+			return fmt.Errorf("Mismatched ip for ingress. Expected: %s Actual: %s", ingressVips[i].String(), vips.IngressVip.IpAddress)
+		}
+	}
+
+	for i := 0; i < len(apiVips); i++ {
+		vipIface, _, err := config.GetVRRPConfig(apiVips[i], ingressVips[i])
+		if err != nil {
+			return err
+		}
+
+		if err = LeaseVIPs(log, cfgPath, vipIface.Name, []vip{vips.APIVips[i], vips.IngressVips[i]}); err != nil {
+			log.WithFields(logrus.Fields{
+				"cfgPath":        cfgPath,
+				"vipMasterIface": vipIface.Name,
+				"vips":           []vip{vips.APIVips[i], vips.IngressVips[i]},
+			}).WithError(err).Error("Failed to lease VIPS")
+			return err
+		}
+	}
+
+	log.WithFields(logrus.Fields{
+		"cfgPath": cfgPath,
+	}).Info("Leased VIPS successfully")
 
 	return nil
 }
@@ -337,7 +361,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			} else {
 				newConfig.EnableUnicast = false
 			}
-			updateUnicastConfig(kubeconfigPath, &newConfig, appliedConfig)
+			updateUnicastConfig(kubeconfigPath, &newConfig)
 
 			log.WithFields(logrus.Fields{
 				"curConfig": newConfig,
@@ -383,7 +407,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				}).Debug("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
 				newConfig.EnableUnicast = curEnableUnicast
 			}
-			updateUnicastConfig(kubeconfigPath, &newConfig, appliedConfig)
+			updateUnicastConfig(kubeconfigPath, &newConfig)
 			curConfig = &newConfig
 			if doesConfigChanged(curConfig, appliedConfig) {
 				if prevConfig == nil || cmp.Equal(*prevConfig, *curConfig) {

--- a/pkg/monitor/lease.go
+++ b/pkg/monitor/lease.go
@@ -27,10 +27,10 @@ type vip struct {
 }
 type yamlVips struct {
 	// Deprecated, use APIVips instead
-	APIVip     *vip `yaml:"api-vip"`
-	APIVips    []vip `yaml:"api-vips"`
+	APIVip  *vip  `yaml:"api-vip"`
+	APIVips []vip `yaml:"api-vips"`
 	// Deprecated, use IngressVips instead
-	IngressVip *vip `yaml:"ingress-vip"`
+	IngressVip  *vip  `yaml:"ingress-vip"`
 	IngressVips []vip `yaml:"ingress-vips"`
 }
 

--- a/pkg/monitor/lease.go
+++ b/pkg/monitor/lease.go
@@ -78,25 +78,25 @@ func parseMonitorFile(buffer []byte) (*yamlVips, error) {
 		return nil, err
 	}
 
-	if vips.APIVip == nil && vips.APIVips == nil {
+	if vips.APIVip == nil && len(vips.APIVips) < 1 {
 		err := fmt.Errorf("APIVip(s) missing from the yaml content")
 		log.Error(err)
 		return nil, err
-	} else if vips.IngressVip == nil && vips.IngressVips == nil {
+	} else if vips.IngressVip == nil && len(vips.IngressVips) < 1 {
 		err := fmt.Errorf("IngressVIP(s) missing from the yaml")
 		log.Error(err)
 		return nil, err
 	}
 
 	// Convert old-style single vip configs to the dual vip format
-	if vips.APIVips == nil {
+	if len(vips.APIVips) < 1 {
 		vips.APIVips = []vip{*vips.APIVip}
 	}
-	if vips.IngressVips == nil {
+	if len(vips.IngressVips) < 1 {
 		vips.IngressVips = []vip{*vips.IngressVip}
 	}
 
-	log.Info(fmt.Sprintf("Valid monitor file format. APIVip: %+v. APIVips: %+v. IngressVip: %+v. IngressVips: %+v.", vips.APIVips, vips.IngressVips))
+	log.Info(fmt.Sprintf("Valid monitor file format. APIVip: %+v. APIVips: %+v. IngressVip: %+v. IngressVips: %+v.", vips.APIVip, vips.APIVips, vips.IngressVip, vips.IngressVips))
 
 	return &vips, nil
 }

--- a/pkg/monitor/lease_test.go
+++ b/pkg/monitor/lease_test.go
@@ -328,9 +328,11 @@ var _ = Describe("getVipsToLease", func() {
 	})
 
 	It("valid_yaml_content", func() {
+		api := vip{"api", generateMac().String(), generateIP()}
+		ingress := vip{"ingress", generateMac().String(), generateIP()}
 		data := yamlVips{
-			APIVip:     &vip{"api", generateMac().String(), generateIP()},
-			IngressVip: &vip{"ingress", generateMac().String(), generateIP()},
+			APIVips:     []vip{api},
+			IngressVips: []vip{ingress},
 		}
 
 		buffer, err := yaml.Marshal(&data)

--- a/pkg/utils/addresses.go
+++ b/pkg/utils/addresses.go
@@ -115,7 +115,7 @@ func usableIPv6Route(route netlink.Route) bool {
 	return true
 }
 
-func isIPv6(ip net.IP) bool {
+func IsIPv6(ip net.IP) bool {
 	return ip.To4() == nil
 }
 
@@ -182,7 +182,7 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 		if len(matches) > 0 {
 			// Find an address of the opposite IP family on the same interface
 			for _, address := range addresses {
-				if isIPv6(address.IP) != isIPv6(matches[0]) {
+				if IsIPv6(address.IP) != IsIPv6(matches[0]) {
 					matches = append(matches, address.IP)
 					break
 				}
@@ -243,7 +243,7 @@ func addressesDefaultInternal(preferIPv6 bool, af AddressFilter, getAddrs addres
 	sort.SliceStable(addrs, func(i, j int) bool {
 		if addrs[i].Priority == addrs[j].Priority {
 			if addrs[i].LinkIndex == addrs[j].LinkIndex {
-				return isIPv6(addrs[i].Address) == preferIPv6 && isIPv6(addrs[j].Address) != preferIPv6
+				return IsIPv6(addrs[i].Address) == preferIPv6 && IsIPv6(addrs[j].Address) != preferIPv6
 			}
 			return addrs[i].LinkIndex < addrs[j].LinkIndex
 		}
@@ -253,11 +253,11 @@ func addressesDefaultInternal(preferIPv6 bool, af AddressFilter, getAddrs addres
 	foundv4 := false
 	foundv6 := false
 	for _, addr := range addrs {
-		if (isIPv6(addr.Address) && foundv6) || (!isIPv6(addr.Address) && foundv4) {
+		if (IsIPv6(addr.Address) && foundv6) || (!IsIPv6(addr.Address) && foundv4) {
 			continue
 		}
 		matches = append(matches, addr.Address)
-		if isIPv6(addr.Address) {
+		if IsIPv6(addr.Address) {
 			foundv6 = true
 		} else {
 			foundv4 = true


### PR DESCRIPTION
The coercion of single vips to a list will no longer be necessary
once we remove the single vip interface to runtimecfg. Make a note
of that in the comments on the code.