### PR TITLE
OCPBUGS-669: Empty chosen list when retrying ip selection

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -181,6 +181,7 @@ func getSuitableIPs(retry bool, vips []net.IP, preferIPv6 bool) (chosen []net.IP
 					if !retry {
 						return nil, fmt.Errorf("Failed to find node IP")
 					}
+					chosen = []net.IP{}
 					time.Sleep(time.Second)
 					continue
 				}


### PR DESCRIPTION
Because chosen is function-scoped, it is persistent over multiple
iterations of the loop. If the first iteration fails and we retry,
the second time around we skip the AddressesDefault case because
chosen is no longer empty. This means the retries will never succeed.

If we just re-initialize the chosen list before retrying then it
should get repopulated the next time through and the retry mechanism
will work as expected.