### PR TITLE
OCPBUGS-673: Apply ipv6 bind check to non-VIP case too

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -181,6 +181,7 @@ func getSuitableIPs(retry bool, vips []net.IP, preferIPv6 bool) (chosen []net.IP
 					if !retry {
 						return nil, fmt.Errorf("Failed to find node IP")
 					}
+					chosen = []net.IP{}
 					time.Sleep(time.Second)
 					continue
 				}


### PR DESCRIPTION
Backport of the two patches needed to make the ipv6 bind check work on UPI platforms too.