### PR TITLE
Add mandre and tsorya as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,7 @@ approvers:
   - creydr
   - cybertron
   - dougsland
+  - mandre
+  - tsorya
 component: Networking
 subcomponent: runtime-cfg


### PR DESCRIPTION
We are perpetually short on approvers for this repo because the team keeps changing. Martin and Igal have done quite a bit of work in and related to this repo so I would be comfortable with them approving changes, especially if we're in a situation where our on-prem networking approver(s) are not available.

I'm not adding them to the reviewers list because I doubt they want to be auto-assigned to patches here, but I'm happy to change that if I'm wrong. :-)