### PR TITLE
OPNET-210: Support preferIPv6 for IPI too

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -211,7 +211,7 @@ func getSuitableIPs(retry bool, vips []net.IP, preferIPv6 bool, networkType stri
 	ipFilterFunc := utils.ValidNodeAddress
 	for {
 		if len(vips) > 0 {
-			chosen, err = utils.AddressesRouting(vips, ipFilterFunc)
+			chosen, err = utils.AddressesRouting(vips, ipFilterFunc, preferIPv6)
 			if len(chosen) > 0 || err != nil {
 				if err == nil {
 					err = checkAddressUsable(chosen)

--- a/pkg/config/net.go
+++ b/pkg/config/net.go
@@ -83,7 +83,7 @@ func getInterfaceAndNonVIPAddr(vips []net.IP) (vipIface net.Interface, nonVipAdd
 					// the candidate address and VIP address are L2 connected.
 					// To make sure that the correct interface being chosen for cases like:
 					// 2 interfaces , subnetA: 1001:db8::/120 , subnetB: 1001:db8::f00/120 and VIP address  1001:db8::64
-					nodeAddrs, err := utils.AddressesRouting(vips, utils.ValidNodeAddress)
+					nodeAddrs, err := utils.AddressesRouting(vips, utils.ValidNodeAddress, utils.IsIPv6(vips[0]))
 					if err == nil && len(nodeAddrs) > 0 && n.IP.Equal(nodeAddrs[0]) {
 						return iface, n, nil
 					}

--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -311,6 +311,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			ipv4AddrMap,
 			ipv4RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5")}))
@@ -322,6 +323,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			ipv4AddrMap,
 			ipv4RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("192.168.1.2")}))
@@ -333,6 +335,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			ipv4AddrMap,
 			ipv4RouteMapDefaultEth1,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5")}))
@@ -344,6 +347,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			ipv6AddrMap,
 			ipv6RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5")}))
@@ -355,6 +359,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			ipv6AddrMap,
 			ipv6RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5")}))
@@ -366,6 +371,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			dualStackAddrMap,
 			dualStackRouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::5")}))
@@ -377,6 +383,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			dualStackAddrMap,
 			dualStackRouteMap,
+			true,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd01::5"), net.ParseIP("192.168.1.2")}))
@@ -489,6 +496,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			overlappingIpv6AddrMap,
 			overlappingIpv6RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::f05")}))
@@ -500,6 +508,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			overlappingIpv6AddrMap,
 			overlappingIpv6RouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5")}))
@@ -511,6 +520,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			overlappingDualStackAddrMap,
 			overlappingDualStackRouteMap,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::f05")}))
@@ -522,6 +532,7 @@ var _ = Describe("addresses", func() {
 			ValidNodeAddress,
 			overlappingDualStackAddrMap,
 			overlappingDualStackRouteMap,
+			true,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addrs).To(Equal([]net.IP{net.ParseIP("fd00::5"), net.ParseIP("192.168.1.2")}))


### PR DESCRIPTION
We added support for the preferIPv6 option in node-ip selection for UPI, but since we always preferred IPv4 in IPI except in v6-only deployments it wasn't wired in for the IPI path. This patch fixes that so we can do v6-primary dual stack deployments and select the appropriate node ip.