### PR TITLE
OCPBUGS-10695: Harden node IP selection to handle IPv6 better

### DIFF
--- a/pkg/utils/addresses.go
+++ b/pkg/utils/addresses.go
@@ -146,6 +146,12 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 		for _, address := range addresses {
 			isVip := false
 			for _, vip := range vips {
+				ip1 := address.Broadcast
+				ip2 := vip.To4()
+				if (ip1 != nil) != (ip2 != nil) {
+					log.Debug("Stack of address '%s' with broadcast '%s' and VIP '%s' does not match. Skipping.", address, address.Broadcast, vip)
+					continue
+				}
 				if address.IP.String() == vip.String() {
 					log.Debugf("Address %s is VIP %s. Skipping.", address, vip)
 					isVip = true
@@ -191,7 +197,7 @@ func addressesRoutingInternal(vips []net.IP, af AddressFilter, getAddrs addressM
 		if len(matches) > 0 {
 			// Find an address of the opposite IP family on the same interface
 			for _, address := range addresses {
-				if IsIPv6(address.IP) != IsIPv6(matches[0]) {
+				if IsNetlinkIPv6(address) != IsIPv6(matches[0]) {
 					matches = append(matches, address.IP)
 					break
 				}

--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,6 +39,12 @@ func maybeAddAddress(addrMap map[netlink.Link][]netlink.Addr, af AddressFilter, 
 	}
 	if !deprecated {
 		addr.PreferedLft = 999
+	}
+	if !strings.Contains(addrStr, ":") {
+		// IPv6 has no broadcast addresses at all. On the other hand IPv4 has them. We are going
+		// to use this property in order to distinguish vanilla IPv4 from IPv4-mapped-to-IPv6.
+		// For the purpose of testing we don't care about the value but only about nil-ness.
+		addr.Broadcast = net.ParseIP("255.255.255.255")
 	}
 	if af != nil && !af(*addr) {
 		return
@@ -102,6 +109,7 @@ func addIPv6Addrs(addrs map[netlink.Link][]netlink.Addr, af AddressFilter) {
 	maybeAddAddress(addrs, af, eth1, "fd01::3/64", true)
 	maybeAddAddress(addrs, af, eth1, "fd01::4/64", true)
 	maybeAddAddress(addrs, af, eth1, "fd01::5/64", false)
+	maybeAddAddress(addrs, af, eth1, "::ffff:192.168.1.160/64", false)
 }
 
 func addIPv6Routes(routes map[int][]netlink.Route, rf RouteFilter) {

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"strings"
+
+	"github.com/vishvananda/netlink"
 )
 
 func SplitCIDR(s string) (string, string, error) {
@@ -17,12 +19,26 @@ func SplitCIDR(s string) (string, string, error) {
 }
 
 func IsIPv4(ip net.IP) bool {
-	// func IsIPv4(ip string) bool {
 	return strings.Contains(ip.String(), ".")
 }
 
 func IsIPv6(ip net.IP) bool {
 	return strings.Contains(ip.String(), ":")
+}
+
+func IsNetlinkIPv6(addr netlink.Addr) bool {
+	// (mko) There may be some corner case when this function returns True, e.g. secondary IP
+	// assigned to the interface. Example below
+	//
+	//   link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
+	//   inet 192.0.2.251/29 brd 192.0.2.255 scope global bond0
+	//      valid_lft forever preferred_lft forever
+	//   inet 192.0.2.249/29 scope global secondary bond0
+	//      valid_lft forever preferred_lft forever
+	if strings.Contains(addr.IP.String(), ":") {
+		return true
+	}
+	return addr.Broadcast == nil
 }
 
 func IpInCidr(ipAddr, cidr string) (bool, error) {


### PR DESCRIPTION
This PR hardens the logic of selecting node IP by adding more sophisticated way of detecting IPv6 addresses. This is because there is a class of IPv4-mapped-to-IPv6 addresses which are represented in the same way as vanilla IPv4 addresses when using net.IP structures.

In order to make our logic more reliable we are now taking into account existence (or not) of the broadcast address on the link. This is because broadcast addresses do not exist in IPv6 world but should be present whenever we deal with a primary IPv4 address on a node.

That way we want to say that if something that looks like an IPv4 address is provided on a link without broadcast address, it may be an IPv6 address.

The implemented logic is not covering all the possible corner cases and in the future PR we may want to also embed a check for subnet mask. E.g. for an IPv4 address with a `/0` mask this is an indicator that the interface was configured with a mapped address and a mask longer than 32.

Contributes-to: OCPBUGS-10695