### PR TITLE
OCPBUGS-10695: Use subnet mask to detect IP stack

### DIFF
--- a/pkg/utils/addresses_test.go
+++ b/pkg/utils/addresses_test.go
@@ -98,6 +98,7 @@ func addIPv6Addrs(addrs map[netlink.Link][]netlink.Addr, af AddressFilter) {
 	maybeAddAddress(addrs, af, lo, "::1/128", false)
 	maybeAddAddress(addrs, af, eth0, "fd00::5/64", false)
 	maybeAddAddress(addrs, af, eth0, "fe80::1234/64", false)
+	maybeAddAddress(addrs, af, eth0, "::ffff:192.168.1.160/64", false)
 	maybeAddAddress(addrs, af, eth1, "fd69::2/125", false)
 	maybeAddAddress(addrs, af, eth1, "fd01::3/64", true)
 	maybeAddAddress(addrs, af, eth1, "fd01::4/64", true)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/sirupsen/logrus"
 )
@@ -134,4 +135,12 @@ func GetClientConfig(kubeApiServerUrl, kubeconfigPath string) (*rest.Config, err
 	// and we should free connection in case it was stuck
 	config.Timeout = kubeClientTimeout
 	return config, err
+}
+
+func Mapper[T, U any](data []T, f func(T) U) []U {
+	res := make([]U, 0, len(data))
+	for _, e := range data {
+		res = append(res, f(e))
+	}
+	return res
 }


### PR DESCRIPTION
This PR hardens the logic of selecting node IP by adding more sophisticated way of detecting IPv6 addresses. This is because there is a class of IPv4-mapped-to-IPv6 addresses which are represented in the same way as vanilla IPv4 addresses when using net.IP structures.

In order to make our logic smarter, we now analyse subnet mask to decide if an address is IPv6 or IPv4. This is because we may have an address `::ffff:192.168.0.160/64` which contains both `:` and `.` making the regular logic unreliable. Knowing that the biggest mask for IPv4 is /32 we may detect if such an address is an IPv4-mapped-to-IPv6 address or vanilla IPv4.

To solve the case of IPv4-mapped-to-IPv6 address in a huge v6 subnet (e.g. `::ffff:192.168.0.160/16`) we are also checking for the capacity of the struct storing subnet mask.

Contributes-to: OCPBUGS-10695