### PR TITLE
OCPBUGS-11297: fix isUpgradeStillRunning()

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -267,11 +267,10 @@ func IsTheSameConfig(nodes []v1.Node) bool {
 // comparing the node's state.
 //
 // Args:
-//      - kubeconfigPath as string
+//   - kubeconfigPath as string
 //
 // Returns:
-//      - true (same config), false or error
-//
+//   - true (different config - upgrade still running), false (upgrade complete) or error
 func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
 	nodes, err := GetNodes(kubeconfigPath)
 	if err != nil {
@@ -281,12 +280,13 @@ func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
 	// Go to all node types identified in GetNodes()
 	for nodeRole := range nodes {
 		nodesConfigs := IsTheSameConfig(nodes[nodeRole])
-		if nodesConfigs {
-			// The configs are the same, NO RUNNING upgrade
-			return false, nil
+
+		if !nodesConfigs {
+			// at least one node group config is different
+			return true, nil
 		}
 	}
-	return true, nil
+	return false, nil
 }
 
 func GetIngressConfig(kubeconfigPath string, filterIpType string) (ingressConfig IngressConfig, err error) {

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -281,11 +281,8 @@ func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
 	// Go to all node types identified in GetNodes()
 	for nodeRole := range nodes {
 		nodesConfigs := IsTheSameConfig(nodes[nodeRole])
-		if err != nil {
-			return false, err
-		}
-
 		if nodesConfigs {
+			// The configs are the same, NO RUNNING upgrade
 			return false, nil
 		}
 	}


### PR DESCRIPTION
- node.go: remove no required check
- Only return false from isUpgradeStillRunning when ALL node groups have same config, not just one of them