### PR TITLE
OCPBUGS-12729: Make nested dual stack VIP configs respect EnableUnicast

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -408,6 +408,13 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				}).Debug("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
 				newConfig.EnableUnicast = curEnableUnicast
 			}
+			// Make sure the nested configs respect the current setting
+			// for EnableUnicast too. In EUS upgrades nodes may make it
+			// to a release with dual stack VIPs without having migrated
+			// to unicast first.
+			for i, _ := range *newConfig.Configs {
+				(*newConfig.Configs)[i].EnableUnicast = newConfig.EnableUnicast
+			}
 			updateUnicastConfig(kubeconfigPath, &newConfig)
 			curConfig = &newConfig
 			if doesConfigChanged(curConfig, appliedConfig) {


### PR DESCRIPTION
Currently the nested configs that were used to enable dual stack VIPs do not respect the EnableUnicast setting correctly, which in the case of EUS upgrades that skip 4.11 can cause problems with the unicast migration being triggered at an incorrect time.

This patch just propagates the EnableUnicast setting into the nested configs so it will apply correctly in dual stack VIP environments.