### PR TITLE
DO NOT MERGE: Test PR to build release image with enable unicast fix

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -407,13 +407,13 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 					"curEnableUnicast":        curEnableUnicast,
 				}).Debug("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
 				newConfig.EnableUnicast = curEnableUnicast
-				// Make sure the nested configs respect the current setting
-				// for EnableUnicast too. In EUS upgrades nodes may make it
-				// to a release with dual stack VIPs without having migrated
-				// to unicast first.
-				for _, c := range *newConfig.Configs {
-					c.EnableUnicast = curEnableUnicast
-				}
+			}
+			// Make sure the nested configs respect the current setting
+			// for EnableUnicast too. In EUS upgrades nodes may make it
+			// to a release with dual stack VIPs without having migrated
+			// to unicast first.
+			for i, _ := range *newConfig.Configs {
+				(*newConfig.Configs)[i].EnableUnicast = newConfig.EnableUnicast
 			}
 			updateUnicastConfig(kubeconfigPath, &newConfig)
 			curConfig = &newConfig
@@ -433,6 +433,9 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 					log.WithFields(logrus.Fields{
 						"curConfig": *curConfig,
 					}).Info("Apply config change")
+					for _, c := range *curConfig.Configs {
+						log.Info(c)
+					}
 
 					err = render.RenderFile(cfgPath, templatePath, newConfig)
 					if err != nil {

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -407,6 +407,13 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 					"curEnableUnicast":        curEnableUnicast,
 				}).Debug("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
 				newConfig.EnableUnicast = curEnableUnicast
+				// Make sure the nested configs respect the current setting
+				// for EnableUnicast too. In EUS upgrades nodes may make it
+				// to a release with dual stack VIPs without having migrated
+				// to unicast first.
+				for _, c := range *newConfig.Configs {
+					c.EnableUnicast = curEnableUnicast
+				}
 			}
 			updateUnicastConfig(kubeconfigPath, &newConfig)
 			curConfig = &newConfig


### PR DESCRIPTION
Currently the nested configs that were used to enable dual stack VIPs do not respect the EnableUnicast setting correctly, which in the case of EUS upgrades that skip 4.11 can cause problems with the unicast migration being triggered at an incorrect time.

This patch just propagates the EnableUnicast setting into the nested configs so it will apply correctly in dual stack VIP environments.

(cherry picked from commit 64751219c12da84d36227e6ab87b26b5ac2a4bc7)