### PR TITLE
DO NOT MERGE: Verify kubelet version in upgrade check

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -408,6 +408,13 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				}).Debug("EnableUnicast != enableUnicast from cfg file, update EnableUnicast value")
 				newConfig.EnableUnicast = curEnableUnicast
 			}
+			// Make sure the nested configs respect the current setting
+			// for EnableUnicast too. In EUS upgrades nodes may make it
+			// to a release with dual stack VIPs without having migrated
+			// to unicast first.
+			for i, _ := range *newConfig.Configs {
+				(*newConfig.Configs)[i].EnableUnicast = newConfig.EnableUnicast
+			}
 			updateUnicastConfig(kubeconfigPath, &newConfig)
 			curConfig = &newConfig
 			if doesConfigChanged(curConfig, appliedConfig) {


### PR DESCRIPTION
In EUS upgrades there is an intermediate step where some nodes are on one version of OCP, while others are on a previous version. When this happens, our upgrade check triggers a unicast migration because all of the machine-config versions match. However, because some nodes are still on the previous version that doesn't have the unicast migration enabled only part of the cluster migrates and you end up with a split brain situation.

The correct flow in this scenario is to wait until all nodes have been upgraded to the same version. To do that, this patch looks at the node kubeletVersion in addition to the machine-config version so if nodes are on different releases the migration will be delayed until that difference is resolved.

(cherry picked from commit 5fd389214f74d17dd8099642398ff24e0a281651)