### PR TITLE
OCPBUGS-11691: Verify kubelet version in upgrade check

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -278,8 +278,21 @@ func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
 		return false, err
 	}
 
+	kubeletVersion := ""
 	// Go to all node types identified in GetNodes()
 	for nodeRole := range nodes {
+		// Verify kubelet versions match. In EUS upgrades we may end up in an
+		// intermediate state where all of the nodes are "updated" as far as
+		// MCO is concerned, but are actually on different versions of OCP.
+		// In those cases, we do not consider the upgrade complete because not
+		// all nodes are ready for migration.
+		if kubeletVersion == "" {
+			kubeletVersion = nodes[nodeRole][0].Status.NodeInfo.KubeletVersion
+		}
+		if kubeletVersion != nodes[nodeRole][0].Status.NodeInfo.KubeletVersion {
+			return true, nil
+		}
+
 		nodesConfigs := IsTheSameConfig(nodes[nodeRole])
 
 		if !nodesConfigs {


### PR DESCRIPTION
In EUS upgrades there is an intermediate step where some nodes are on one version of OCP, while others are on a previous version. When this happens, our upgrade check triggers a unicast migration because all of the machine-config versions match. However, because some nodes are still on the previous version that doesn't have the unicast migration enabled only part of the cluster migrates and you end up with a split brain situation.

The correct flow in this scenario is to wait until all nodes have been upgraded to the same version. To do that, this patch looks at the node kubeletVersion in addition to the machine-config version so if nodes are on different releases the migration will be delayed until that difference is resolved.