### PR TITLE
OCPBUGS-12739: Print error message when node annotation doesn't parse

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -388,7 +388,9 @@ func getNodeIpForRequestedIpStack(node v1.Node, filterIps []string, machineNetwo
 
 		var ovnHostAddresses []string
 		if err := json.Unmarshal([]byte(node.Annotations["k8s.ovn.org/host-addresses"]), &ovnHostAddresses); err != nil {
-			log.Warnf("Couldn't unmarshall OVN annotations: '%s'. Skipping.", node.Annotations["k8s.ovn.org/host-addresses"])
+			log.WithFields(logrus.Fields{
+				"err": err,
+			}).Warnf("Couldn't unmarshall OVN annotations: '%s'. Skipping.", node.Annotations["k8s.ovn.org/host-addresses"])
 		}
 
 	AddrList:


### PR DESCRIPTION
This PR modifies the logging so that when we fail to parse the OVN annotation on the Node CR, we also print the error message. Currently the error message is quietly dropped so we can see that we failed, but we don't see why.

Contributes-to: OCPBUGS-12739