### PR TITLE
OCPBUGS-12739: Dump whole Node object when failing to get node IP

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -391,6 +391,7 @@ func getNodeIpForRequestedIpStack(node v1.Node, filterIps []string, machineNetwo
 			log.WithFields(logrus.Fields{
 				"err": err,
 			}).Warnf("Couldn't unmarshall OVN annotations: '%s'. Skipping.", node.Annotations["k8s.ovn.org/host-addresses"])
+			log.Debugf("Dumping node object: %+v", node)
 		}
 
 	AddrList:


### PR DESCRIPTION
With this PR we are going to print a dump of the whole Node object in case when an attempt to get the Node IPs fails. This should help debug cases when we are trying to parse an empty annotation even when we believe it contains the required data.

Contributes-to: OCPBUGS-12739