### PR TITLE
OCPBUGS-12739: Use lazy match when getting IP from OVN

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -416,6 +416,7 @@ func getNodeIpForRequestedIpStack(node v1.Node, filterIps []string, machineNetwo
 			if match {
 				addr = hostAddr
 				log.Infof("For node %s selected peer address %s using using OVN annotations.", node.Name, addr)
+				break AddrList
 			}
 		}
 	}


### PR DESCRIPTION
With this PR the logic of getting the Node IP from OVN annotations is becoming lazy, i.e. it stops running as soon as the first matching IP is found. This is to remediate a scenario in which the node has multiple matching IP addresses and some parts of the code use the first one, whereas other parts of the code use the last one matching.

E.g. we have a code that collects

```
IngressVIP:fd65:a1a8:60ad:271c::201
```

and for the same node we have the OVN annotation containing

```
'["192.168.90.29","fd65:a1a8:60ad:271c::71","fd65:a1a8:60ad:271c:9e72:83b8:ffa6:ece1"]'
```

With the current logic, we will have

```
time="2023-05-30T09:19:41Z" level=info msg="For node ci-ln-wmb6p1b-c1627-gdhjq-master-0 can't find address using NodeInternalIP. Fallback to OVN annotation."
time="2023-05-30T09:19:41Z" level=info msg="Address 192.168.90.29 doesn't match requested IP stack. Skipping."
time="2023-05-30T09:19:41Z" level=info msg="For node ci-ln-wmb6p1b-c1627-gdhjq-master-0 selected peer address fd65:a1a8:60ad:271c::71 using using OVN annotations."
time="2023-05-30T09:19:41Z" level=info msg="For node ci-ln-wmb6p1b-c1627-gdhjq-master-0 selected peer address fd65:a1a8:60ad:271c:9e72:83b8:ffa6:ece1 using using OVN annotations."
```

so we end up on one hand with `fd65:a1a8:60ad:271c::201` and on the other hand with `fd65:a1a8:60ad:271c:9e72:83b8:ffa6:ece1` which are obviously different IP addresses.

Then in the template rendering keepalived.conf we have the following

```
{{- range .LBConfig.Backends}}
{{- if eq $nonVirtualIP .Address}}
{{$participateInAPIVRPP = true}}
{{- end}}
{{- end}}
```

so we try to compare both addresses and only if they are equal, we generate a `vrrp_instance` stanza in the keepalived config file. In this scenario here we obviously don't generate it as addresses are different.

It's worth noting this code doesn't ultimately solve the issue - the ideal would be to iterate over all the IP addresses and compare them. However for simplicity we are piggybacking on the fact of how IP addresses are sorted around various places, as the ideal solution would require reimplementing too many things around.

It's also worth noting that the issue exposes itself only in setups where both SLAAC and DHCPv6 are used. If only single method is used to configure IPv6 addresses, then we are not running into scenario when the node has multiple IPs in its machine network and the issue simply cannot happen.

Fixes: OCPBUGS-12739