### PR TITLE
[release-4.11] OCPBUGS-15539: Use machine-config state instead of comparing roles

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -175,8 +175,8 @@ func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh 
 
 	// create Ticker that will run every round modeUpdateIntervalInSec
 	nextTickTime := time.Now().Add((modeUpdateIntervalInSec / 2) * time.Second).Round(modeUpdateIntervalInSec * time.Second)
-	time.Sleep(time.Until(nextTickTime))
-	ticker := time.NewTicker(modeUpdateIntervalInSec * time.Second)
+	// The first tick happens on nextTickTime, then we reset to the regular interval
+	ticker := time.NewTicker(time.Until(nextTickTime))
 	defer ticker.Stop()
 
 	for {
@@ -184,6 +184,7 @@ func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh 
 		select {
 		case tickerTime := <-ticker.C:
 
+			ticker.Reset(modeUpdateIntervalInSec * time.Second)
 			updateRequired, desiredModeInfo := isModeUpdateNeeded(cfgPath)
 			if !updateRequired {
 				continue


### PR DESCRIPTION
This is a manual cherry-pick of #262 . It appears the backport was not clean simply due to whitespace changes.