### PR TITLE
OCPBUGS-18257: Move haproxy firewall rule check earlier in loop

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -407,6 +407,34 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			appliedConfig = curConfig
 
 		default:
+			// Signal to keepalived whether the haproxy firewall rule is in place
+			// The rules are all managed as a single entity, so we should only need
+			// to check the first VIP.
+			// NOTE(bnemec): We are now doing this first so it doesn't get skipped
+			// if there is a problem updating the peer list below, which can result
+			// in the VIP remaining on a node without API connectivity.
+			ruleExists, err := checkHAProxyFirewallRules(apiVips[0].String(), apiPort, lbPort)
+			if err != nil {
+				log.Error("Failed to check for haproxy firewall rule")
+			} else {
+				_, err := os.Stat(iptablesFilePath)
+				fileExists := !os.IsNotExist(err)
+				if ruleExists {
+					if !fileExists {
+						_, err := os.Create(iptablesFilePath)
+						if err != nil {
+							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to create file")
+						}
+					}
+				} else {
+					if fileExists {
+						err := os.Remove(iptablesFilePath)
+						if err != nil {
+							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to remove file")
+						}
+					}
+				}
+			}
 			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0)
 			if err != nil {
 				return err
@@ -477,31 +505,6 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			}
 			prevConfig = &newConfig
 
-			// Signal to keepalived whether the haproxy firewall rule is in place
-			// The rules are all managed as a single entity, so we should only need
-			// to check the first VIP.
-			ruleExists, err := checkHAProxyFirewallRules(apiVips[0].String(), apiPort, lbPort)
-			if err != nil {
-				log.Error("Failed to check for haproxy firewall rule")
-			} else {
-				_, err := os.Stat(iptablesFilePath)
-				fileExists := !os.IsNotExist(err)
-				if ruleExists {
-					if !fileExists {
-						_, err := os.Create(iptablesFilePath)
-						if err != nil {
-							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to create file")
-						}
-					}
-				} else {
-					if fileExists {
-						err := os.Remove(iptablesFilePath)
-						if err != nil {
-							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to remove file")
-						}
-					}
-				}
-			}
 			time.Sleep(interval)
 		}
 	}


### PR DESCRIPTION
When we stopped rendering config if we were unable to update the peer list[0] we also stopped checking the haproxy firewall rule status if there was a problem contacting the API. What this means is that we may not correctly update the priority of a node with no access to the API, causing the VIP to stay there when it should migrate to a different node.

I think this will mostly happen during initial deployment when the apiserver may become briefly unavailable. If this happens haproxy will remove the firewall rule so we fall back to direct un-loadbalanced API access, but if there isn't an apiserver instance running on the node yet that won't work either. There's no way for the healthchecks to recover from this situation.

To fix this I just moved the firewall rule check to be first in the loop flow so it will get run even if we bail out early due to a failure in contacting the API.

0: 18bc0e360f6430fd1ec52db83b77841c30c5e8fa