### PR TITLE
[release-4.11] OCPBUGS-18815: Move haproxy firewall rule check earlier in loop

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -380,6 +380,32 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			appliedConfig = curConfig
 
 		default:
+			// Signal to keepalived whether the haproxy firewall rule is in place
+			// NOTE(bnemec): We are now doing this first so it doesn't get skipped
+			// if there is a problem updating the peer list below, which can result
+			// in the VIP remaining on a node without API connectivity.
+			ruleExists, err := checkHAProxyFirewallRules(apiVip.String(), apiPort, lbPort)
+			if err != nil {
+				log.Error("Failed to check for haproxy firewall rule")
+			} else {
+				_, err := os.Stat(iptablesFilePath)
+				fileExists := !os.IsNotExist(err)
+				if ruleExists {
+					if !fileExists {
+						_, err := os.Create(iptablesFilePath)
+						if err != nil {
+							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to create file")
+						}
+					}
+				} else {
+					if fileExists {
+						err := os.Remove(iptablesFilePath)
+						if err != nil {
+							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to remove file")
+						}
+					}
+				}
+			}
 			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVip, ingressVip, 0, 0, 0)
 			if err != nil {
 				return err
@@ -442,29 +468,6 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			}
 			prevConfig = &newConfig
 
-			// Signal to keepalived whether the haproxy firewall rule is in place
-			ruleExists, err := checkHAProxyFirewallRules(apiVip.String(), apiPort, lbPort)
-			if err != nil {
-				log.Error("Failed to check for haproxy firewall rule")
-			} else {
-				_, err := os.Stat(iptablesFilePath)
-				fileExists := !os.IsNotExist(err)
-				if ruleExists {
-					if !fileExists {
-						_, err := os.Create(iptablesFilePath)
-						if err != nil {
-							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to create file")
-						}
-					}
-				} else {
-					if fileExists {
-						err := os.Remove(iptablesFilePath)
-						if err != nil {
-							log.WithFields(logrus.Fields{"path": iptablesFilePath}).Error("Failed to remove file")
-						}
-					}
-				}
-			}
 			time.Sleep(interval)
 		}
 	}


### PR DESCRIPTION
When we stopped rendering config if we were unable to update the peer list[0] we also stopped checking the haproxy firewall rule status if there was a problem contacting the API. What this means is that we may not correctly update the priority of a node with no access to the API, causing the VIP to stay there when it should migrate to a different node.

I think this will mostly happen during initial deployment when the apiserver may become briefly unavailable. If this happens haproxy will remove the firewall rule so we fall back to direct un-loadbalanced API access, but if there isn't an apiserver instance running on the node yet that won't work either. There's no way for the healthchecks to recover from this situation.

To fix this I just moved the firewall rule check to be first in the loop flow so it will get run even if we bail out early due to a failure in contacting the API.

Merge conflict resolution: A few minor changes due to dual stack vips. I just re-copy-pasted the firewall rule check to ensure we get consistent references in this release.

0: 18bc0e360f6430fd1ec52db83b77841c30c5e8fa
(cherry picked from commit 92dd8f0d3ac3033def7ab139f0d8cc9db733fa67)