### PR TITLE
OCPBUGS-19492: Increase timeout for bootstrap kubeapi

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -147,11 +147,13 @@ func isModeUpdateNeeded(cfgPath string) (bool, modeUpdateInfo) {
 func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalived chan APIState) {
 	consecutiveErr := 0
 
-	/* It could take up to ~20 seconds for the local kube-apiserver to start running on the bootstrap node,
-	so before checking if kube-apiserver is not operational we should verify (with a timeout of 30 seconds)
-	first that it's operational. */
+	/* It should take up to ~20 seconds for the local kube-apiserver to start running on the
+	bootstrap node,	so before doing anything we should verify that it's operational. Usually this
+	causes no trouble, but every now and then (e.g. when performance is not great) we can see that
+	this needs much longer timeout. We add here 30 minutes as an equivalent of infinity.
+	*/
 	log.Info("handleBootstrapStopKeepalived: verify first that local kube-apiserver is operational")
-	for start := time.Now(); time.Since(start) < time.Second*30; {
+	for start := time.Now(); time.Since(start) < time.Minute*30; {
 		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}); err == nil {
 			log.Info("handleBootstrapStopKeepalived: local kube-apiserver is operational")
 			break


### PR DESCRIPTION
We are increasing timeout for waiting for boostrap keepalived from the current 30 seconds to 30 minutes. This is because we observed environments where 30 seconds is not enough for the kube-api to start yet it does start eventually after much longer time.

We don't understand why kube-api is so slow on the bootstrap node in those cases but as this timeout has no any deeper meaning it is safe to just increase it to extremely big value.

Contributes-to: OCPBUGS-19492