### PR TITLE
CORS-2818: Adding ability to render Cloud LB IPs

### DIFF
--- a/cmd/corednsmonitor/corednsmonitor.go
+++ b/cmd/corednsmonitor/corednsmonitor.go
@@ -55,8 +55,20 @@ func main() {
 			if err != nil {
 				return err
 			}
+			cloudExtLBIPs, err := cmd.Flags().GetIPSlice("cloud-ext-lb-ips")
+			if err != nil {
+				cloudExtLBIPs = []net.IP{}
+			}
+			cloudIntLBIPs, err := cmd.Flags().GetIPSlice("cloud-int-lb-ips")
+			if err != nil {
+				cloudIntLBIPs = []net.IP{}
+			}
+			cloudIngressLBIPs, err := cmd.Flags().GetIPSlice("cloud-ingress-lb-ips")
+			if err != nil {
+				cloudIngressLBIPs = []net.IP{}
+			}
 
-			return monitor.CorednsWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, checkInterval)
+			return monitor.CorednsWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, checkInterval, cloudExtLBIPs, cloudIntLBIPs, cloudIngressLBIPs)
 		},
 	}
 	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")

--- a/pkg/monitor/dnsmasqmonitor.go
+++ b/pkg/monitor/dnsmasqmonitor.go
@@ -33,7 +33,7 @@ func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVips []net.IP
 			return nil
 		default:
 			// We only care about the api vip and cluster domain here
-			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVips, apiVips, 0, 0, 0)
+			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVips, apiVips, 0, 0, 0, config.ClusterLBConfig{})
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -355,7 +355,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 
 		case desiredModeInfo := <-updateModeCh:
 
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{})
 			if err != nil {
 				return err
 			}
@@ -437,7 +437,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 					}
 				}
 			}
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Add the ability to render and monitor Cloud LB IPs. This capability is used only when `userProvisionedDNS` is enabled on some (AWS, GCP and Azure) cloud platforms via install-config.
    
On some cloud platforms (AWS, Azure, GCP), the user cannot use the cloud's default DNS solution. They are expected to use their own custom DNS solution that is external to the cluster. OpenShift is not allowed to configure this DNS solution. In this scenario, these same customers want to continue using the cloud provided Load Balancers (LBs).
    
OpenShift is expected to continue configuing the cloud LBs for API, API-Int and Ingress access. Since the LB information is not available, before cluster installation, the user cannot configure their custom DNS solution before cluster installation.
    
So, to support this mode, OpenShift needs to start its in-cluster CoreDNS based DNS solution for API, API-Int and Ingress resolution so that cluster installation is successful. The customer is expected to configure their DNS solution post-install.
    
At this the time, the cloud's API and API-Int LBs are configured by the Installer and its value is not expected to change during the life of the cluster. The Ingress operator continues to handle Ingress LB configuration.
    
Based on enhancement: https://github.com/openshift/enhancements/pull/1468
