### PR TITLE
OCPBUGS-23432: Use shorter IP label for keepalived VIP

### DIFF
--- a/test/data/keepalived.conf.tmpl
+++ b/test/data/keepalived.conf.tmpl
@@ -21,7 +21,7 @@ vrrp_instance {{.Cluster.Name}}_API {
         auth_pass {{.Cluster.Name}}_api_vip
     }
     virtual_ipaddress {
-        {{.Cluster.APIVIP}}/{{.Cluster.VIPNetmask}} label {{.VRRPInterface}}:vip
+        {{.Cluster.APIVIP}}/{{.Cluster.VIPNetmask}} label vip
     }
     track_script {
         chk_ocp
@@ -39,7 +39,7 @@ vrrp_instance {{.Cluster.Name}}_INGRESS {
         auth_pass {{.Cluster.Name}}_ingress_vip
     }
     virtual_ipaddress {
-        {{.Cluster.IngressVIP}}/{{.Cluster.VIPNetmask}} label {{.VRRPInterface}}:vip
+        {{.Cluster.IngressVIP}}/{{.Cluster.VIPNetmask}} label vip
     }
     track_script {
         chk_ingress


### PR DESCRIPTION
This PR modifies the label used for an IP address assigned by keepalived to not include the name of the interface. This is because the maximum allowed lenght of the label is 15 characters, causing stuff to fail when interface itself has a name longer than 12 characters.

With this change the label will always be a simple string of length 3 and will not be susceptible to overflow for long NIC names.

Contributes-to: OCPBUGS-23432