### PR TITLE
OCPBUGS-26765: Add .snyk file to ignore vendor and test files

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"


### PR DESCRIPTION
These files either come from other projects or are not used in production so there's no reason to security scan them.