### PR TITLE
OCPBUGS-32348: Make log level configurable

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -223,6 +223,11 @@ func getSuitableIPs(retry bool, vips []net.IP, preferIPv6 bool, networkType stri
 	// for the next loop interation.
 	timerLoop := 1
 
+	// Enable debug logging in utils package if requested
+	if os.Getenv("ENABLE_NODEIP_DEBUG") == "true" {
+		utils.SetDebugLogLevel()
+	}
+
 	ipFilterFunc := utils.ValidNodeAddress
 	for {
 		timerLoop = timerLoop * addSecondsToSuitableIPsLoop


### PR DESCRIPTION
In https://github.com/openshift/baremetal-runtimecfg/pull/301 we have decreased level from INFO to DEBUG for multiple messages around Node IP detection logic. However, we never implemented ability to enable DEBUG level so that those logs were effectively unreachable.

With this PR we will consume `ENABLE_NODEIP_DEBUG` env variable and if configured, we will increase log level.

For OpenShift customers the variable will be consumed via ConfigMap as defined in the respective Pod manifest in the MCO repository.

Fixes: OCPBUGS-32348