### PR TITLE
NO-ISSUE: Fix wrong golang version, bump to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN mkdir build


### PR DESCRIPTION
go.mod for quite some time defines golang version as 1.21, yet Dockerfile was never upgraded from 1.18

In order to make local builds possible again, we need to bump golang version in Dockerfile.