### PR TITLE
OCPBUGS-32141: Handle scenario when VIP does not belong to L2

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -605,22 +605,41 @@ func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.
 	// by detecting which of the local interfaces belongs to the same subnet as requested VIP.
 	// This interface can be used to detect what was the original machine network as it contains
 	// the subnet mask that we need.
+	// In case there is no subnet containing a VIP on any of the available NICs we are counterintuitively
+	// selecting just a Node IP with the matching IP stack. This is a weird case in e.g. vSphere
+	// where VIPs do not belong to the L2 of the node, yet they work properly.
 	machineNetwork, err := utils.GetLocalCIDRByIP(vips[0].String())
-	if err != nil {
+	if err == nil {
+		for _, node := range nodes.Items {
+			masterIp, err := getNodeIpForRequestedIpStack(node, utils.ConvertIpsToStrings(vips), machineNetwork)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"err": err,
+				}).Warnf("Could not retrieve node's IP for %s. Ignoring", node.ObjectMeta.Name)
+			} else {
+				backends = append(backends, Backend{Host: node.ObjectMeta.Name, Address: masterIp})
+			}
+		}
+	} else {
 		log.WithFields(logrus.Fields{
 			"err": err,
-		}).Errorf("Could not retrieve subnet for IP %s", vips[0].String())
-		return []Backend{}, err
-	}
+		}).Errorf("Could not retrieve subnet for IP %s. Falling back to an IP of the matching IP stack", vips[0].String())
 
-	for _, node := range nodes.Items {
-		masterIp, err := getNodeIpForRequestedIpStack(node, utils.ConvertIpsToStrings(vips), machineNetwork)
-		if err != nil {
-			log.WithFields(logrus.Fields{
-				"err": err,
-			}).Warnf("Could not retrieve node's IP for %s. Ignoring", node.ObjectMeta.Name)
-		} else {
-			backends = append(backends, Backend{Host: node.ObjectMeta.Name, Address: masterIp})
+		for _, node := range nodes.Items {
+			masterIp := ""
+			for _, address := range node.Status.Addresses {
+				if address.Type == v1.NodeInternalIP && utils.IsIPv6(net.ParseIP(address.Address)) == utils.IsIPv6(vips[0]) {
+					masterIp = address.Address
+					break
+				}
+			}
+			if masterIp != "" {
+				backends = append(backends, Backend{Host: node.ObjectMeta.Name, Address: masterIp})
+			} else {
+				log.WithFields(logrus.Fields{
+					"err": err,
+				}).Warnf("Could not retrieve node's IP for %s. Ignoring", node.ObjectMeta.Name)
+			}
 		}
 	}
 


### PR DESCRIPTION
Lately we were made aware that the current logic of maching interfaces to VIPs is broken in vSphere IPI scenarios when VIP does not belong to Machine Network. Usually such a combination would be forbidden, but for vSphere it is allowed.

As a result, we may have e.g. an interface 10.8.38.29, machine network 10.8.42.0/23 and VIP 10.8.0.83. As counterintuitively it looks for baremetal, with vSphere it is allowed.

This PR fixes the logic we introduced in January 2023 where we added a hard-check to make sure VIP belongs to a subnet of the NIC. With this new logic, if the scenario described above happens, we will fallback to the logic from years ago when we were simply choosing a NodeInternalIP of the matching IP stack.

Closes: OCPBUGS-32141