### PR TITLE
OCPBUGS-32141: Handle scenario when VIP does not belong to L2 (addn. for ingress)

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -309,20 +309,44 @@ func GetIngressConfig(kubeconfigPath string, vips []string) (IngressConfig, erro
 		// by detecting which of the local interfaces belongs to the same subnet as requested VIP.
 		// This interface can be used to detect what was the original machine network as it contains
 		// the subnet mask that we need.
+		//
+		// In case there is no subnet containing a VIP on any of the available NICs we are counterintuitively
+		// selecting just a Node IP with the matching IP stack. This is a weird case in e.g. vSphere
+		// where VIPs do not belong to the L2 of the node, yet they work properly.
 		machineNetwork, err = utils.GetLocalCIDRByIP(vips[0])
-		if err != nil {
-			return ingressConfig, err
-		}
-	}
 
-	for _, node := range nodes.Items {
-		addr, err := getNodeIpForRequestedIpStack(node, vips, machineNetwork)
-		if err != nil {
+		if err == nil {
+			for _, node := range nodes.Items {
+				addr, err := getNodeIpForRequestedIpStack(node, vips, machineNetwork)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"err": err,
+					}).Warnf("For node %s could not retrieve node's IP. Ignoring", node.ObjectMeta.Name)
+				} else {
+					ingressConfig.Peers = append(ingressConfig.Peers, addr)
+				}
+			}
+		} else {
 			log.WithFields(logrus.Fields{
 				"err": err,
-			}).Warnf("For node %s could not retrieve node's IP. Ignoring", node.ObjectMeta.Name)
-		} else {
-			ingressConfig.Peers = append(ingressConfig.Peers, addr)
+			}).Errorf("Could not retrieve subnet for IP %s. Falling back to an IP of the matching IP stack", vips[0])
+
+			for _, node := range nodes.Items {
+				addr := ""
+				for _, address := range node.Status.Addresses {
+					if address.Type == v1.NodeInternalIP && utils.IsIPv6(net.ParseIP(address.Address)) == utils.IsIPv6(net.ParseIP(vips[0])) {
+						addr = address.Address
+						break
+					}
+				}
+				if addr != "" {
+					ingressConfig.Peers = append(ingressConfig.Peers, addr)
+				} else {
+					log.WithFields(logrus.Fields{
+						"err": err,
+					}).Warnf("Could not retrieve node's IP for %s. Ignoring", node.ObjectMeta.Name)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/openshift/baremetal-runtimecfg/pull/313 we have fixed logic for topologies where VIP does not belong to the L2 of the node. But this change was missing additional part of the code that had the same flaw, i.e. generation of ingress config.

This PR is replicating the fix #313.

Fixes: OCPBUGS-32141