### PR TITLE
OCPBUGS-32141: Fix handling of ELB Node IP detection

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -646,7 +646,7 @@ func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.
 	sort.Slice(backends, func(i, j int) bool {
 		return backends[i].Address < backends[j].Address
 	})
-	return backends, err
+	return backends, nil
 }
 
 func GetLBConfig(kubeconfigPath string, apiPort, lbPort, statPort uint16, vips []net.IP) (ApiLBConfig, error) {

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -309,20 +309,44 @@ func GetIngressConfig(kubeconfigPath string, vips []string) (IngressConfig, erro
 		// by detecting which of the local interfaces belongs to the same subnet as requested VIP.
 		// This interface can be used to detect what was the original machine network as it contains
 		// the subnet mask that we need.
+		//
+		// In case there is no subnet containing a VIP on any of the available NICs we are counterintuitively
+		// selecting just a Node IP with the matching IP stack. This is a weird case in e.g. vSphere
+		// where VIPs do not belong to the L2 of the node, yet they work properly.
 		machineNetwork, err = utils.GetLocalCIDRByIP(vips[0])
-		if err != nil {
-			return ingressConfig, err
-		}
-	}
 
-	for _, node := range nodes.Items {
-		addr, err := getNodeIpForRequestedIpStack(node, vips, machineNetwork)
-		if err != nil {
+		if err == nil {
+			for _, node := range nodes.Items {
+				addr, err := getNodeIpForRequestedIpStack(node, vips, machineNetwork)
+				if err != nil {
+					log.WithFields(logrus.Fields{
+						"err": err,
+					}).Warnf("For node %s could not retrieve node's IP. Ignoring", node.ObjectMeta.Name)
+				} else {
+					ingressConfig.Peers = append(ingressConfig.Peers, addr)
+				}
+			}
+		} else {
 			log.WithFields(logrus.Fields{
 				"err": err,
-			}).Warnf("For node %s could not retrieve node's IP. Ignoring", node.ObjectMeta.Name)
-		} else {
-			ingressConfig.Peers = append(ingressConfig.Peers, addr)
+			}).Errorf("Could not retrieve subnet for IP %s. Falling back to an IP of the matching IP stack", vips[0])
+
+			for _, node := range nodes.Items {
+				addr := ""
+				for _, address := range node.Status.Addresses {
+					if address.Type == v1.NodeInternalIP && utils.IsIPv6(net.ParseIP(address.Address)) == utils.IsIPv6(net.ParseIP(vips[0])) {
+						addr = address.Address
+						break
+					}
+				}
+				if addr != "" {
+					ingressConfig.Peers = append(ingressConfig.Peers, addr)
+				} else {
+					log.WithFields(logrus.Fields{
+						"err": err,
+					}).Warnf("Could not retrieve node's IP for %s. Ignoring", node.ObjectMeta.Name)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/openshift/baremetal-runtimecfg/pull/313 we have fixed some logic regarding to VIPs in ELB scenario, but we forgot to handle the error. Because of this, even if we detected the IP correctly, the function could stil return a non-empty error causing the installation to fail.

This PR contains a simple fix to return `nil` instead of `err` in case we managed to recover from the issue.

A second commit fixes the issue where the change was missing additional part of the code that had the same flaw, i.e. generation of ingress config.

Fixes: OCPBUGS-32141