### PR TITLE
OCPBUGS-34706: Add support for OVN HostCidrs annotation

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -349,7 +349,8 @@ func getNodeIpForRequestedIpStack(node v1.Node, filterIps []string, machineNetwo
 	//
 	// We will use here the following sources:
 	//   1) Node.Status.Addresses list
-	//   2) Node annotation "k8s.ovn.org/host-addresses" in combination with Machine Networks
+	//   2) Node annotation "k8s.ovn.org/host-cidrs" in combination with Machine Networks
+	//   3) Deprecated node annotation "k8s.ovn.org/host-addresses" in combination with Machine Networks
 	//
 	// If none of those returns a conclusive result, we don't return an IP for this node. This is
 	// not a desired outcome, but can be extended in the future if desired.
@@ -367,10 +368,24 @@ func getNodeIpForRequestedIpStack(node v1.Node, filterIps []string, machineNetwo
 		log.Debugf("For node %s can't find address using NodeInternalIP. Fallback to OVN annotation.", node.Name)
 
 		var ovnHostAddresses []string
-		if err := json.Unmarshal([]byte(node.Annotations["k8s.ovn.org/host-addresses"]), &ovnHostAddresses); err != nil {
+		var tmp []string
+
+		err := json.Unmarshal([]byte(node.Annotations["k8s.ovn.org/host-cidrs"]), &tmp)
+		if err == nil {
+			for _, cidr := range tmp {
+				ip := strings.Split(cidr, "/")[0]
+				ovnHostAddresses = append(ovnHostAddresses, ip)
+			}
+		} else {
 			log.WithFields(logrus.Fields{
 				"err": err,
-			}).Warnf("Couldn't unmarshall OVN annotations: '%s'. Skipping.", node.Annotations["k8s.ovn.org/host-addresses"])
+			}).Warnf("Couldn't unmarshall OVN HostCidrs annotations: '%s'. Trying HostAddresses.", node.Annotations["k8s.ovn.org/host-cidrs"])
+
+			if err := json.Unmarshal([]byte(node.Annotations["k8s.ovn.org/host-addresses"]), &ovnHostAddresses); err != nil {
+				log.WithFields(logrus.Fields{
+					"err": err,
+				}).Warnf("Couldn't unmarshall OVN HostAddresses annotations: '%s'. Skipping.", node.Annotations["k8s.ovn.org/host-addresses"])
+			}
 		}
 
 		// Here we need to guarantee that local Node IP (i.e. NonVirtualIP) is present somewhere

--- a/pkg/config/node_test.go
+++ b/pkg/config/node_test.go
@@ -16,6 +16,10 @@ var (
 		"k8s.ovn.org/host-addresses": "[\"192.168.1.102\",\"192.168.1.99\",\"192.168.1.101\",\"fd00::101\",\"2001:db8::49a\",\"fd00::102\",\"fd00::5\",\"fd69::2\"]",
 	}
 
+	testOvnHostCidrsAnnotation = map[string]string{
+		"k8s.ovn.org/host-cidrs": "[\"192.168.1.102/24\",\"192.168.1.99/24\",\"192.168.1.101/24\",\"fd00::101/128\",\"2001:db8::49a/64\",\"fd00::102/128\",\"fd00::5/128\",\"fd69::2/128\"]",
+	}
+
 	testNodeDualStack1 = v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
 		Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
@@ -24,7 +28,6 @@ var (
 			{Type: "ExternalIP", Address: "172.16.1.99"},
 		}}}
 	testNodeDualStack2 = v1.Node{
-
 		Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
 			{Type: "InternalIP", Address: "192.168.1.99"},
 			{Type: "ExternalIP", Address: "172.16.1.99"},
@@ -40,6 +43,23 @@ var (
 			Annotations: testOvnHostAddressesAnnotation,
 		},
 	}
+	testNodeDualStack4 = v1.Node{
+		Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
+			{Type: "InternalIP", Address: "192.168.1.99"},
+			{Type: "ExternalIP", Address: "172.16.1.99"},
+		}},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testNode",
+			Annotations: testOvnHostCidrsAnnotation,
+		},
+	}
+	testNodeDualStack5 = v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testNode",
+			Annotations: testOvnHostCidrsAnnotation,
+		},
+	}
+
 	testNodeSingleStackV4 = v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
 		Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
@@ -76,7 +96,7 @@ var _ = Describe("getNodePeersForIpStack", func() {
 			})
 		})
 
-		Context("with address only in OVN annotation", func() {
+		Context("with address only in OVN HostAddresses annotation", func() {
 			It("matches an IPv4 VIP", func() {
 				res, err := getNodeIpForRequestedIpStack(testNodeDualStack3, []string{testApiVipV4, testIngressVipV4}, testMachineNetworkV4)
 				Expect(res).To(Equal("192.168.1.99"))
@@ -89,7 +109,20 @@ var _ = Describe("getNodePeersForIpStack", func() {
 			})
 		})
 
-		Context("with address in status and OVN annotation", func() {
+		Context("with address only in OVN HostCidrs annotation", func() {
+			It("matches an IPv4 VIP", func() {
+				res, err := getNodeIpForRequestedIpStack(testNodeDualStack5, []string{testApiVipV4, testIngressVipV4}, testMachineNetworkV4)
+				Expect(res).To(Equal("192.168.1.99"))
+				Expect(err).To(BeNil())
+			})
+			It("matches an IPv6 VIP", func() {
+				res, err := getNodeIpForRequestedIpStack(testNodeDualStack5, []string{testApiVipV6, testIngressVipV6}, testMachineNetworkV6)
+				Expect(res).To(Equal("fd00::5"))
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with address in status and OVN HostAddresses annotation", func() {
 			It("matches an IPv4 VIP", func() {
 				res, err := getNodeIpForRequestedIpStack(testNodeDualStack2, []string{testApiVipV4, testIngressVipV4}, testMachineNetworkV4)
 				Expect(res).To(Equal("192.168.1.99"))
@@ -97,6 +130,19 @@ var _ = Describe("getNodePeersForIpStack", func() {
 			})
 			It("matches an IPv6 VIP", func() {
 				res, err := getNodeIpForRequestedIpStack(testNodeDualStack2, []string{testApiVipV6, testIngressVipV6}, testMachineNetworkV6)
+				Expect(res).To(Equal("fd00::5"))
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with address in status and OVN HostCidrs annotation", func() {
+			It("matches an IPv4 VIP", func() {
+				res, err := getNodeIpForRequestedIpStack(testNodeDualStack4, []string{testApiVipV4, testIngressVipV4}, testMachineNetworkV4)
+				Expect(res).To(Equal("192.168.1.99"))
+				Expect(err).To(BeNil())
+			})
+			It("matches an IPv6 VIP", func() {
+				res, err := getNodeIpForRequestedIpStack(testNodeDualStack4, []string{testApiVipV6, testIngressVipV6}, testMachineNetworkV6)
 				Expect(res).To(Equal("fd00::5"))
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
This PR adds logic for extracting IP addresses for the Node from a newly added OVN annotation `k8s.ovn.org/host-cidrs`.

Till now we were only using the `k8s.ovn.org/host-addresses` annotation which is now deprecated in favour of the one mentioned above.

Fixes: OCPBUGS-34706