### PR TITLE
OCPBUGS-38281: Handle errors in iptables healthcheck

### DIFF
--- a/pkg/monitor/iptables.go
+++ b/pkg/monitor/iptables.go
@@ -113,12 +113,18 @@ func checkHAProxyFirewallRules(apiVip string, apiPort, lbPort uint16) (bool, err
 	if err != nil {
 		return false, err
 	}
-	preroutingExists, _ := ipt.Exists(table, "PREROUTING", ruleSpec...)
+	preroutingExists, err := ipt.Exists(table, "PREROUTING", ruleSpec...)
+	if err != nil {
+		return false, err
+	}
 
 	ruleSpec, err = getHAProxyRuleSpec(apiVip, apiPort, lbPort, isLoopback)
 	if err != nil {
 		return false, err
 	}
-	outputExists, _ := ipt.Exists(table, "OUTPUT", ruleSpec...)
+	outputExists, err := ipt.Exists(table, "OUTPUT", ruleSpec...)
+	if err != nil {
+		return false, err
+	}
 	return (preroutingExists && outputExists), nil
 }


### PR DESCRIPTION
Previously we ignored errors from the exists call in the firewall rule check. This can cause problems if the check fails for reasons other than the non-existence of the rule, such as a permission error on iptables. If the check returns err we should handle that and report the problem rather than just report that the firewall rule doesn't exist (which may or may not be true).