### PR TITLE
OPNET-552: Move to stream9 for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN mkdir build
 RUN GO111MODULE=on go build --mod=vendor -o build ./cmd/...
 
-FROM centos:stream8
+FROM centos:stream9
 
 RUN yum install -y dhcp-client diffutils && yum clean all
 


### PR DESCRIPTION
CentOS Stream 8 has gone out of support and because of that the mirrorlist record no longer exists. This causes local builds to fail and doesn't match what we're actually using in the product now anyway. This just moves the image from stream8 to stream9.