### PR TITLE
Update go.mod directive to 1.22.0 for cachito

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/baremetal-runtimecfg
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/coreos/go-iptables v0.4.1


### PR DESCRIPTION
For cachito to work for downstream builds, we need to adjust the go.mod directive

Test downstream build: [ose-baremetal-runtimecfg-container-v4.17.0-202408202005.p0.gdcb68b3.assembly.test.el9](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=3237451)