### PR TITLE
OCPBUGS-38877: Increase "fall" value for haproxy-monitor check

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -18,7 +18,7 @@ import (
 const haproxyMasterSock = "/var/run/haproxy/haproxy-master.sock"
 const cfgChangeThreshold uint8 = 3
 const k8sHealthThresholdOn uint8 = 3
-const k8sHealthThresholdOff uint8 = 2
+const k8sHealthThresholdOff uint8 = 3
 
 var log = logrus.New()
 


### PR DESCRIPTION
When we check for API connectivity through HAProxy in the monitor container, we're only allowing it to fail twice before we mark the node as unhealthy and remove the firewall rule. This is probably a bit too strict, especially during graceful shutdown where we may happen to have our requests loadbalanced to nodes that are shutting down. Let's bump this value to 3 and see if it helps with this scenario.

Note that this is not expected to happen in normal operation of the cluster, so it should not be necessary for us to detect outages in this area very quickly. This is more of a last ditch attempt to keep the API accessible in case something has gone drastically wrong in the cluster to the point where HAProxy has stopped functioning correctly.