### PR TITLE
OPNET-629: Use HAProxy monitor endpoint instead of API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.22 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN mkdir build


### PR DESCRIPTION
This is the runtimecfg change corresponding to
https://github.com/openshift/machine-config-operator/pull/4767
which switches the monitor call to the HAProxy endpoing rather than
call through to the API.

I also included a commit to bump the Dockerfile image to golang 1.22 to match the current state of the code.