### PR TITLE
[release-4.17] OCPBUGS-48766: Extend haproxy-monitor fall time

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -18,7 +18,7 @@ import (
 const haproxyMasterSock = "/var/run/haproxy/haproxy-master.sock"
 const cfgChangeThreshold uint8 = 3
 const k8sHealthThresholdOn uint8 = 3
-const k8sHealthThresholdOff uint8 = 2
+const k8sHealthThresholdOff uint8 = 11
 
 var log = logrus.New()
 


### PR DESCRIPTION
Once the HAProxy firewall rule has been created we do not expect it to need to be removed in normal functioning of the cluster. The more important part of this check is to ensure that we don't insert the rule before HAProxy is fully configured and ready to accept API traffic. Removing the rule due to health check failures is more of an escape hatch in case of an unexpected failure of HAProxy.

This increases the required failure count to 11. That should ensure we never fail the check in less than 60 seconds, which is important now that the HAProxy health checks may take up to 15 seconds to detect a failure in a backend. The previous value of 3 meant we might trigger a failure in as little as 12 seconds, which is shorter than the 15 second worst case to detect a backend outage.

(cherry picked from commit b4d96701d9cb2c23531c91eabee6f88a5f20a92f)