### PR TITLE
OCPBUGS-48469: Include cloud platform specific parameters to argument list for corednsmonitor 

### DIFF
--- a/cmd/corednsmonitor/corednsmonitor.go
+++ b/cmd/corednsmonitor/corednsmonitor.go
@@ -77,6 +77,10 @@ func main() {
 	rootCmd.Flags().IPSlice("api-vips", nil, "Virtual IP Addresses to reach the OpenShift API")
 	rootCmd.Flags().IP("ingress-vip", nil, "DEPRECATED: Virtual IP Address to reach the OpenShift Ingress Routers")
 	rootCmd.Flags().IPSlice("ingress-vips", nil, "Virtual IP Addresses to reach the OpenShift Ingress Routers")
+	rootCmd.Flags().IPSlice("cloud-ext-lb-ips", nil, "IP Addresses of Cloud External Load Balancers for OpenShift API")
+	rootCmd.Flags().IPSlice("cloud-int-lb-ips", nil, "IP Addresses of Cloud Internal Load Balancers for OpenShift Internal API")
+	rootCmd.Flags().IPSlice("cloud-ingress-lb-ips", nil, "IP Addresses of Cloud Ingress Load Balancers")
+
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}


### PR DESCRIPTION
Include cloud platform specific parameters to argument list for corednsmonitor