### PR TITLE
OPNET-629: Use HAProxy monitor endpoint instead of API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.22 AS builder
 WORKDIR /go/src/github.com/openshift/baremetal-runtimecfg
 COPY . .
 RUN mkdir build


### PR DESCRIPTION
Same as #336 which was reverted because it merged before a dependency in MCO.