### PR TITLE
OCPEDGE-1689: Include Arbiter nodes in the API backends if there is only one master

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -100,6 +100,7 @@ func doesConfigChanged(curConfig, appliedConfig *config.Node) bool {
 	// approach we should avoid asymetric configuration
 	if curConfig.EnableUnicast {
 		if os.Getenv("IS_BOOTSTRAP") == "no" && len(curConfig.LBConfig.Backends) < 2 {
+			log.Warnf("Invalid keepalived.conf - number of backends must be at least 2 got %d", len(curConfig.LBConfig.Backends))
 			validConfig = false
 		}
 	}


### PR DESCRIPTION
Following the [enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/arbiter-clusters.md) for TNA clusters, we want to install this new type of cluster using Assisted-Service.

Currently there is a problem when installing TNA clusters using Assisted-Service, because in Assisted-Service one of the master nodes acts as the bootstrap. So during the installation there will only be one master node, but we need two in order for keepalived-monitor to configure keepalived.
We cannot wait until the bootstrap finishes and becomes a master, because then no node will have the API vip.
To circumvent that we will add the arbiter node to the list of nodes.