### PR TITLE
OCPBUGS-55971: Re-add ENABLE_NODEIP_DEBUG env var

### DIFF
--- a/cmd/runtimecfg/node-ip.go
+++ b/cmd/runtimecfg/node-ip.go
@@ -223,6 +223,11 @@ func getSuitableIPs(retry bool, vips []net.IP, preferIPv6 bool, networkType stri
 	// for the next loop interation.
 	timerLoop := 1
 
+	// Enable debug logging in utils package if requested
+	if os.Getenv("ENABLE_NODEIP_DEBUG") == "true" {
+		utils.SetDebugLogLevel()
+	}
+
 	ipFilterFunc := utils.ValidNodeAddress
 	for {
 		timerLoop = timerLoop * addSecondsToSuitableIPsLoop


### PR DESCRIPTION
This was added and reverted back when we first started to support configurable logging. It was eventually replaced by the config-map, but there are circumstances where we want to always enable debug logging, specifically in the nodeip-configuration service. Using the env var will let us set it in the service and always have it take effect, regardless of the user settings.