### PR TITLE
MGMT-20739: Add control-plane-topology as an arg to dynkeepalived and temporarily add a dummy backend when installing TNF/TNA with assisted-installer

### DIFF
--- a/cmd/dynkeepalived/dynkeepalived.go
+++ b/cmd/dynkeepalived/dynkeepalived.go
@@ -69,8 +69,12 @@ func main() {
 			if err != nil {
 				platformType = ""
 			}
+			controlPlaneTopology, err := cmd.Flags().GetString("control-plane-topology")
+			if err != nil {
+				controlPlaneTopology = ""
+			}
 
-			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, apiPort, lbPort, checkInterval, platformType)
+			return monitor.KeepalivedWatch(args[0], clusterConfigPath, args[1], args[2], apiVips, ingressVips, apiPort, lbPort, checkInterval, platformType, controlPlaneTopology)
 		},
 	}
 	rootCmd.PersistentFlags().StringP("cluster-config", "c", "", "Path to cluster-config ConfigMap to retrieve ControlPlane info")
@@ -83,6 +87,7 @@ func main() {
 	rootCmd.Flags().Uint16("api-port", 6443, "Port where the OpenShift API listens")
 	rootCmd.Flags().Uint16("lb-port", 9445, "Port where the API HAProxy LB will listen")
 	rootCmd.Flags().StringP("platform", "p", "", "Cluster Platform")
+	rootCmd.Flags().String("control-plane-topology", "", "Cluster Control Plane Topology")
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed due to %s", err)
 	}

--- a/cmd/runtimecfg/display.go
+++ b/cmd/runtimecfg/display.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"net"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/openshift/baremetal-runtimecfg/pkg/config"
 	"github.com/spf13/cobra"
-	"net"
 )
 
 var (
@@ -108,7 +109,7 @@ func runDisplay(cmd *cobra.Command, args []string) error {
 
 	clusterLBConfig := config.ClusterLBConfig{ApiLBIPs: apiLBIPs, ApiIntLBIPs: apiIntLBIPs, IngressLBIPs: ingressLBIPs}
 
-	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType)
+	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -111,7 +111,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 	}
 
 	clusterLBConfig := config.ClusterLBConfig{ApiLBIPs: apiLBIPs, ApiIntLBIPs: apiIntLBIPs, IngressLBIPs: ingressLBIPs}
-	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType)
+	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/monitor/corednsmonitor.go
+++ b/pkg/monitor/corednsmonitor.go
@@ -43,7 +43,7 @@ func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath strin
 				return err
 			}
 			clusterLBConfig := config.ClusterLBConfig{ApiLBIPs: apiLBIPs, ApiIntLBIPs: apiIntLBIPs, IngressLBIPs: ingressLBIPs}
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, resolvConfFilepath, apiVips, ingressVips, 0, 0, 0, clusterLBConfig, platformType)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, resolvConfFilepath, apiVips, ingressVips, 0, 0, 0, clusterLBConfig, platformType, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/dnsmasqmonitor.go
+++ b/pkg/monitor/dnsmasqmonitor.go
@@ -33,7 +33,7 @@ func DnsmasqWatch(kubeconfigPath, templatePath, cfgPath string, apiVips []net.IP
 			return nil
 		default:
 			// We only care about the api vip and cluster domain here
-			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVips, apiVips, 0, 0, 0, config.ClusterLBConfig{}, platformType)
+			config, err := config.GetConfig(kubeconfigPath, "", "/etc/resolv.conf", apiVips, apiVips, 0, 0, 0, config.ClusterLBConfig{}, platformType, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -70,7 +70,7 @@ func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node) error {
 		return err
 	}
 
-	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(newConfig.Cluster.APIVIP), net.ParseIP(newConfig.Cluster.IngressVIP)})
+	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(newConfig.Cluster.APIVIP), net.ParseIP(newConfig.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology)
 	if err != nil {
 		log.Warnf("Could not retrieve LB config: %v", err)
 		return err
@@ -83,7 +83,7 @@ func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node) error {
 			log.Warnf("Could not retrieve ingress config: %v", err)
 			return err
 		}
-		(*newConfig.Configs)[i].LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(c.Cluster.APIVIP), net.ParseIP(c.Cluster.IngressVIP)})
+		(*newConfig.Configs)[i].LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(c.Cluster.APIVIP), net.ParseIP(c.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology)
 		if err != nil {
 			log.Warnf("Could not retrieve LB config: %v", err)
 			return err
@@ -291,7 +291,7 @@ func handleLeasing(cfgPath string, apiVips, ingressVips []net.IP) error {
 	return nil
 }
 
-func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVips, ingressVips []net.IP, apiPort, lbPort uint16, interval time.Duration, platformType string) error {
+func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVips, ingressVips []net.IP, apiPort, lbPort uint16, interval time.Duration, platformType string, controlPlaneTopology string) error {
 	var appliedConfig, curConfig, prevConfig *config.Node
 	var configChangeCtr uint8 = 0
 
@@ -356,7 +356,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 
 		case desiredModeInfo := <-updateModeCh:
 
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{}, platformType)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{}, platformType, controlPlaneTopology)
 			if err != nil {
 				return err
 			}
@@ -431,7 +431,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 				// if the path doesn't exist then RemoveAll returns nil
 				log.WithFields(logrus.Fields{"path": iptablesFilePath}).WithError(err).Error("Failed to remove file")
 			}
-			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{}, platformType)
+			newConfig, err := config.GetConfig(kubeconfigPath, clusterConfigPath, "/etc/resolv.conf", apiVips, ingressVips, 0, 0, 0, config.ClusterLBConfig{}, platformType, controlPlaneTopology)
 			if err != nil {
 				return err
 			}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -58,7 +58,7 @@ func Monitor(kubeconfigPath, clusterName, clusterDomain, templatePath, cfgPath s
 			}
 			return nil
 		default:
-			config, err := config.GetLBConfig(kubeconfigPath, apiPort, lbPort, statPort, []net.IP{net.ParseIP(apiVips[0])})
+			config, err := config.GetLBConfig(kubeconfigPath, apiPort, lbPort, statPort, []net.IP{net.ParseIP(apiVips[0])}, "")
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"kubeconfigPath": kubeconfigPath,


### PR DESCRIPTION
This PR does 2 things:
1. Add control-plane-topology as an arg to dynkeepalived.
2. Temporarily add a dummy backend when installing TNF/TNA with assisted-installer.

When installing TNF/TNA with assisted-installer, 1 of the control plane nodes acts as the bootstrap which means that during the installation there is only going to be 1 control plane node ready. This causes the keepalived-monitor container not to generate the keepalived.conf. So we need a temporary workaround during the installation, and we only want that workaround to happen when the cluster is TNF/TNA. So if the cluster is TNF/TNA and there is only 1 backend then we'll add 0.0.0.0 as a dummy backend just so keepalived.conf will be generated and keepalived will work in unicast mode. After the bootstrap becomes a control plane node, it's will replace the dummy in the backends list.

This PR also removes the existing workaround implemented for TNA, since this new workaround works for TNA as well.