### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,11 @@
 reviewers:
   - cybertron
-  - dougsland
   - emy
   - mkowalski
 approvers:
   - cybertron
-  - dougsland
+  - emy
   - mkowalski
-  - mandre
-  - tsorya
+  - rbbratta
 component: Networking
 subcomponent: runtime-cfg


### PR DESCRIPTION
Now that the team is a more reasonable size, we don't need to have emergency approvers from other teams anymore.

I left Ross off the reviewer list because I expect he'll get added as the QE assignee to patches he needs to look at anyway.