### PR TITLE
MGMT-22546: Fix TNA and TNF dummy ip for ipv6

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -743,7 +743,11 @@ func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.
 	// After the bootstrap becomes a master node, it's ip will replace the dummy ip in the list.
 	if len(nodes.Items) == 1 &&
 		(controlPlaneTopology == highlyAvailableArbiterMode || controlPlaneTopology == dualReplicaTopologyMode) {
-		backends = append(backends, Backend{Host: "dummy", Address: "0.0.0.0"})
+		if utils.IsIPv4(vips[0]) {
+			backends = append(backends, Backend{Host: "dummy", Address: "0.0.0.0"})
+		} else {
+			backends = append(backends, Backend{Host: "dummy", Address: "::"})
+		}
 	}
 
 	sort.Slice(backends, func(i, j int) bool {


### PR DESCRIPTION
A bit of backround:
When installing TNA/TNF clusters using assisted service, one of the master nodes acts as the bootstrap.
So during the installation there will only be one master node, but we need two in order to configure keepalived.
We cannot wait until the bootstrap finishes and becomes a master, because then no node will have the API vip.
To circumvent that we temporarily add a dummy ip to the list of nodes.
After the bootstrap becomes a master node, it's ip replaces the dummy ip in the list.

What does this PR do:
Right now the dummy ip is always 0.0.0.0, but that doesn't work for clusters that are using ipv6.
This PR fixes that so that if the vip is an ipv4 address then the dummy ip will be 0.0.0.0, but if not the dummy ip will be ::