### PR TITLE
OCPBUGS-42805: Add node caching with Kubernetes watch API to reduce API load

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -270,14 +270,31 @@ func GetVRRPConfig(apiVip, ingressVip net.IP) (vipIface net.Interface, nonVipAdd
 	return getInterfaceAndNonVIPAddr(vips)
 }
 
+// NodeCacheGetter is an interface for getting cached node information.
+// This allows us to use either the NodeWatcher cache or fall back to direct API calls.
+type NodeCacheGetter interface {
+	GetNodes() *v1.NodeList
+	GetMasterNodes() *v1.NodeList
+	GetNodeCount() int
+}
+
 // GetNodes will return a list of all nodes in the cluster
 //
 // Args:
 //   - kubeconfigPath as string
+//   - nodeCache (optional) - if provided, uses cached data instead of API call
 //
 // Returns:
 //   - v1.NodeList or error
-func GetNodes(kubeconfigPath string) (*v1.NodeList, error) {
+func GetNodes(kubeconfigPath string, nodeCache NodeCacheGetter) (*v1.NodeList, error) {
+	// If a cache is provided, use it
+	if nodeCache != nil {
+		log.Debugf("Node cache available. Contains %d nodes.", nodeCache.GetNodeCount())
+		return nodeCache.GetNodes(), nil
+	}
+
+	// Fall back to direct API call
+	log.Debugf("Node cache not available. Falling back to direct API call.")
 	config, err := utils.GetClientConfig("", kubeconfigPath)
 	if err != nil {
 		return nil, err
@@ -295,6 +312,44 @@ func GetNodes(kubeconfigPath string) (*v1.NodeList, error) {
 	return nodes, nil
 }
 
+// GetMasterNodesWithConfig returns a list of master nodes in the cluster.
+// Supports custom API server URL for special cases (e.g., localhost for bootstrap).
+//
+// Args:
+//   - kubeApiServerUrl - custom API server URL (empty string for default)
+//   - kubeconfigPath - path to kubeconfig
+//   - nodeCache (optional) - if provided, uses cached data instead of API call
+//
+// Returns:
+//   - v1.NodeList or error
+func GetMasterNodesWithConfig(kubeApiServerUrl, kubeconfigPath string, nodeCache NodeCacheGetter) (*v1.NodeList, error) {
+	// If a cache is provided, use it
+	if nodeCache != nil {
+		log.Debugf("Node cache available. Contains %d nodes.", nodeCache.GetNodeCount())
+		return nodeCache.GetMasterNodes(), nil
+	}
+
+	// Fall back to direct API call
+	log.Debugf("Node cache not available. Falling back to direct API call.")
+	config, err := utils.GetClientConfig(kubeApiServerUrl, kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/master=",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
 // IsUpgradeStillRunning check if the upgrade is still running by looking at
 // the nodes' machineconfiguration state and kubelet version. Once all of the
 // machineconfigurations are Done and all kubelet versions match we know it
@@ -302,11 +357,12 @@ func GetNodes(kubeconfigPath string) (*v1.NodeList, error) {
 //
 // Args:
 //   - kubeconfigPath as string
+//   - nodeCache (optional) - if provided, uses cached data instead of API call
 //
 // Returns:
 //   - true (upgrade still running), false (upgrade complete) or error
-func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
-	nodes, err := GetNodes(kubeconfigPath)
+func IsUpgradeStillRunning(kubeconfigPath string, nodeCache NodeCacheGetter) (bool, error) {
+	nodes, err := GetNodes(kubeconfigPath, nodeCache)
 	if err != nil {
 		return false, err
 	}
@@ -332,20 +388,11 @@ func IsUpgradeStillRunning(kubeconfigPath string) (bool, error) {
 	return false, nil
 }
 
-func GetIngressConfig(kubeconfigPath string, vips []string) (IngressConfig, error) {
+func GetIngressConfig(kubeconfigPath string, vips []string, nodeCache NodeCacheGetter) (IngressConfig, error) {
 	var machineNetwork string
 	var ingressConfig IngressConfig
 
-	config, err := utils.GetClientConfig("", kubeconfigPath)
-	if err != nil {
-		return ingressConfig, err
-	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return ingressConfig, err
-	}
-
-	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := GetNodes(kubeconfigPath, nodeCache)
 	if err != nil {
 		return ingressConfig, err
 	}
@@ -665,25 +712,13 @@ func getNodeConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, api
 
 // getSortedBackends builds config to communicate with kube-api based on kubeconfigPath parameter value, if kubeconfigPath is not empty it will build the
 // config based on that content else config will point to localhost.
-func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.IP, controlPlaneTopology string) (backends []Backend, err error) {
+func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.IP, controlPlaneTopology string, nodeCache NodeCacheGetter) (backends []Backend, err error) {
 	kubeApiServerUrl := ""
 	if readFromLocalAPI {
 		kubeApiServerUrl = localhostKubeApiServerUrl
 	}
-	config, err := utils.GetClientConfig(kubeApiServerUrl, kubeconfigPath)
-	if err != nil {
-		return []Backend{}, err
-	}
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"err": err,
-		}).Info("Failed to get client")
-		return []Backend{}, err
-	}
-	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
-		LabelSelector: "node-role.kubernetes.io/master=",
-	})
+
+	nodes, err := GetMasterNodesWithConfig(kubeApiServerUrl, kubeconfigPath, nodeCache)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"err": err,
@@ -752,7 +787,7 @@ func getSortedBackends(kubeconfigPath string, readFromLocalAPI bool, vips []net.
 	return backends, nil
 }
 
-func GetLBConfig(kubeconfigPath string, apiPort, lbPort, statPort uint16, vips []net.IP, controlPlaneTopology string) (ApiLBConfig, error) {
+func GetLBConfig(kubeconfigPath string, apiPort, lbPort, statPort uint16, vips []net.IP, controlPlaneTopology string, nodeCache NodeCacheGetter) (ApiLBConfig, error) {
 	config := ApiLBConfig{
 		ApiPort:  apiPort,
 		LbPort:   lbPort,
@@ -768,11 +803,11 @@ func GetLBConfig(kubeconfigPath string, apiPort, lbPort, statPort uint16, vips [
 		config.FrontendAddr = "::"
 	}
 	// Try reading master nodes details first from api-vip:kube-apiserver and failover to localhost:kube-apiserver
-	backends, err := getSortedBackends(kubeconfigPath, false, vips, controlPlaneTopology)
+	backends, err := getSortedBackends(kubeconfigPath, false, vips, controlPlaneTopology, nodeCache)
 	if err != nil {
 		log.Infof("An error occurred while trying to read master nodes details from api-vip:kube-apiserver: %v", err)
 		log.Infof("Trying to read master nodes details from localhost:kube-apiserver")
-		backends, err = getSortedBackends(kubeconfigPath, true, vips, controlPlaneTopology)
+		backends, err = getSortedBackends(kubeconfigPath, true, vips, controlPlaneTopology, nodeCache)
 		if err != nil {
 			log.WithFields(logrus.Fields{
 				"kubeconfigPath": kubeconfigPath,
@@ -802,20 +837,8 @@ func GetClusterNameAndDomain(kubeconfigPath, clusterConfigPath string) (clusterN
 	return
 }
 
-func PopulateNodeAddresses(kubeconfigPath string, node *Node) {
-	// Get node list
-	config, err := utils.GetClientConfig("", kubeconfigPath)
-	if err != nil {
-		log.Errorf("Failed to build client config: %s", err)
-		return
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Errorf("Failed to create client: %s", err)
-		return
-	}
-	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+func PopulateNodeAddresses(kubeconfigPath string, node *Node, nodeCache NodeCacheGetter) {
+	nodes, err := GetNodes(kubeconfigPath, nodeCache)
 	if err != nil {
 		log.Errorf("Failed to get node list: %s", err)
 		return

--- a/pkg/loggingconfig/watcher.go
+++ b/pkg/loggingconfig/watcher.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/openshift/baremetal-runtimecfg/pkg/config"
+	"github.com/openshift/baremetal-runtimecfg/pkg/nodeconfig"
 	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
 )
 
@@ -149,10 +150,12 @@ func (w *Watcher) setDebugEnabled(debug bool, forceUpdate bool) {
 	if debug {
 		log.Info("Debug logging enabled")
 		config.SetDebugLogLevel()
+		nodeconfig.SetDebugLogLevel()
 		utils.SetDebugLogLevel()
 	} else {
 		log.Info("Debug logging disabled")
 		config.SetInfoLogLevel()
+		nodeconfig.SetInfoLogLevel()
 		utils.SetInfoLogLevel()
 	}
 

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/baremetal-runtimecfg/pkg/config"
 	"github.com/openshift/baremetal-runtimecfg/pkg/loggingconfig"
+	"github.com/openshift/baremetal-runtimecfg/pkg/nodeconfig"
 	"github.com/openshift/baremetal-runtimecfg/pkg/render"
 )
 
@@ -61,19 +62,19 @@ func getActualMode(cfgPath string) (error, bool) {
 	return nil, enableUnicast
 }
 
-func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node) error {
+func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node, nodeCache config.NodeCacheGetter) error {
 	var err error
 
 	if !newConfig.EnableUnicast {
 		return err
 	}
-	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath, []string{newConfig.Cluster.APIVIP, newConfig.Cluster.IngressVIP})
+	newConfig.IngressConfig, err = config.GetIngressConfig(kubeconfigPath, []string{newConfig.Cluster.APIVIP, newConfig.Cluster.IngressVIP}, nodeCache)
 	if err != nil {
 		log.Warnf("Could not retrieve ingress config: %v", err)
 		return err
 	}
 
-	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(newConfig.Cluster.APIVIP), net.ParseIP(newConfig.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology)
+	newConfig.LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(newConfig.Cluster.APIVIP), net.ParseIP(newConfig.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology, nodeCache)
 	if err != nil {
 		log.Warnf("Could not retrieve LB config: %v", err)
 		return err
@@ -81,12 +82,12 @@ func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node) error {
 
 	for i, c := range *newConfig.Configs {
 		// Must do this by index instead of using c because c is local to this loop
-		(*newConfig.Configs)[i].IngressConfig, err = config.GetIngressConfig(kubeconfigPath, []string{c.Cluster.APIVIP, c.Cluster.IngressVIP})
+		(*newConfig.Configs)[i].IngressConfig, err = config.GetIngressConfig(kubeconfigPath, []string{c.Cluster.APIVIP, c.Cluster.IngressVIP}, nodeCache)
 		if err != nil {
 			log.Warnf("Could not retrieve ingress config: %v", err)
 			return err
 		}
-		(*newConfig.Configs)[i].LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(c.Cluster.APIVIP), net.ParseIP(c.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology)
+		(*newConfig.Configs)[i].LBConfig, err = config.GetLBConfig(kubeconfigPath, dummyPortNum, dummyPortNum, dummyPortNum, []net.IP{net.ParseIP(c.Cluster.APIVIP), net.ParseIP(c.Cluster.IngressVIP)}, newConfig.Cluster.ControlPlaneTopology, nodeCache)
 		if err != nil {
 			log.Warnf("Could not retrieve LB config: %v", err)
 			return err
@@ -148,7 +149,7 @@ func isModeUpdateNeeded(cfgPath string) (bool, modeUpdateInfo) {
 	return updateRequired, desiredModeInfo
 }
 
-func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalived chan APIState) {
+func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalived chan APIState, nodeCache config.NodeCacheGetter) {
 	consecutiveErr := 0
 
 	/* It should take up to ~20 seconds for the local kube-apiserver to start running on the
@@ -158,7 +159,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	*/
 	log.Info("handleBootstrapStopKeepalived: verify first that local kube-apiserver is operational")
 	for start := time.Now(); time.Since(start) < time.Minute*30; {
-		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}); err == nil {
+		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}, nodeCache); err == nil {
 			log.Info("handleBootstrapStopKeepalived: local kube-apiserver is operational")
 			break
 		}
@@ -167,7 +168,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	}
 
 	for {
-		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}); err != nil {
+		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}, nodeCache); err != nil {
 			// We have started to talk to Ironic through the API VIP as well,
 			// so if Ironic is still up then we need to keep the VIP, even if
 			// the apiserver has gone down.
@@ -194,7 +195,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	}
 }
 
-func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh chan modeUpdateInfo) {
+func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh chan modeUpdateInfo, nodeCache config.NodeCacheGetter) {
 
 	// create Ticker that will run every round modeUpdateIntervalInSec
 	nextTickTime := time.Now().Add((modeUpdateIntervalInSec / 2) * time.Second).Round(modeUpdateIntervalInSec * time.Second)
@@ -218,7 +219,7 @@ func handleConfigModeUpdate(cfgPath string, kubeconfigPath string, updateModeCh 
 			}).Info("Update Mode request detected, verify that upgrade process completed")
 
 			// before applying mode update we should verify that upgrade process completed.
-			upgradeRunning, err := config.IsUpgradeStillRunning(kubeconfigPath)
+			upgradeRunning, err := config.IsUpgradeStillRunning(kubeconfigPath, nodeCache)
 			if err != nil || upgradeRunning {
 				log.WithFields(logrus.Fields{
 					"err":            err,
@@ -320,17 +321,25 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 	}
 	go loggingWatcher.Run(ctx)
 
+	// Initialize the node watcher to cache node information
+	nodeWatcher, err := nodeconfig.NewNodeWatcher(kubeconfigPath)
+	if err != nil {
+		log.WithError(err).Error("Failed to init node watcher")
+		return err
+	}
+	go nodeWatcher.Run(ctx)
+
 	updateModeCh := make(chan modeUpdateInfo, 1)
 	bootstrapStopKeepalived := make(chan APIState, 1)
 
-	go handleConfigModeUpdate(cfgPath, kubeconfigPath, updateModeCh)
+	go handleConfigModeUpdate(cfgPath, kubeconfigPath, updateModeCh, nodeWatcher)
 
 	if os.Getenv("IS_BOOTSTRAP") == "yes" {
 		/* When OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP is set to true the bootstrap node won't be destroyed and
 		   Keepalived on the bootstrap continue to run, this behavior might cause problems when unicast keepalived being used,
 		   so, Keepalived on bootstrap should stop running when local kube-apiserver isn't operational anymore.
 		   handleBootstrapStopKeepalived function is responsible to stop Keepalived when the condition is met. */
-		go handleBootstrapStopKeepalived(kubeconfigPath, bootstrapStopKeepalived)
+		go handleBootstrapStopKeepalived(kubeconfigPath, bootstrapStopKeepalived, nodeWatcher)
 	}
 
 	conn, err := net.Dial("unix", keepalivedControlSock)
@@ -385,7 +394,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			}
 			// We have to get a valid unicast config before the migration
 			for {
-				err = updateUnicastConfig(kubeconfigPath, &newConfig)
+				err = updateUnicastConfig(kubeconfigPath, &newConfig, nodeWatcher)
 				if err == nil {
 					break
 				}
@@ -464,7 +473,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 			for i, _ := range *newConfig.Configs {
 				(*newConfig.Configs)[i].EnableUnicast = newConfig.EnableUnicast
 			}
-			err = updateUnicastConfig(kubeconfigPath, &newConfig)
+			err = updateUnicastConfig(kubeconfigPath, &newConfig, nodeWatcher)
 			if err != nil {
 				// We don't want to render a new config with an incomplete
 				// unicast peer list

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -339,7 +339,9 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		   Keepalived on the bootstrap continue to run, this behavior might cause problems when unicast keepalived being used,
 		   so, Keepalived on bootstrap should stop running when local kube-apiserver isn't operational anymore.
 		   handleBootstrapStopKeepalived function is responsible to stop Keepalived when the condition is met. */
-		go handleBootstrapStopKeepalived(kubeconfigPath, bootstrapStopKeepalived, nodeWatcher)
+
+		// Additionally, on bootstrap we don't care about caching the nodes because we don't need performance optimizations.
+		go handleBootstrapStopKeepalived(kubeconfigPath, bootstrapStopKeepalived, nil)
 	}
 
 	conn, err := net.Dial("unix", keepalivedControlSock)

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -58,7 +58,7 @@ func Monitor(kubeconfigPath, clusterName, clusterDomain, templatePath, cfgPath s
 			}
 			return nil
 		default:
-			config, err := config.GetLBConfig(kubeconfigPath, apiPort, lbPort, statPort, []net.IP{net.ParseIP(apiVips[0])}, "")
+			config, err := config.GetLBConfig(kubeconfigPath, apiPort, lbPort, statPort, []net.IP{net.ParseIP(apiVips[0])}, "", nil)
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"kubeconfigPath": kubeconfigPath,

--- a/pkg/nodeconfig/log.go
+++ b/pkg/nodeconfig/log.go
@@ -1,0 +1,21 @@
+package nodeconfig
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+func init() {
+	log.SetLevel(logrus.InfoLevel)
+}
+
+// SetDebugLogLevel sets the log level to debug
+func SetDebugLogLevel() {
+	log.SetLevel(logrus.DebugLevel)
+}
+
+// SetInfoLogLevel sets the log level to info
+func SetInfoLogLevel() {
+	log.SetLevel(logrus.InfoLevel)
+}

--- a/pkg/nodeconfig/nodeconfig_suite_test.go
+++ b/pkg/nodeconfig/nodeconfig_suite_test.go
@@ -1,0 +1,21 @@
+package nodeconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNodeConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeConfig Suite")
+}
+
+var _ = BeforeSuite(func() {
+	// Test suite setup if needed
+})
+
+var _ = AfterSuite(func() {
+	// Test suite cleanup if needed
+})

--- a/pkg/nodeconfig/watcher.go
+++ b/pkg/nodeconfig/watcher.go
@@ -1,0 +1,187 @@
+package nodeconfig
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/baremetal-runtimecfg/pkg/utils"
+)
+
+const (
+	defaultWatchRetryInterval = 5 * time.Second
+)
+
+// NodeWatcher watches the Kubernetes Node objects and maintains a cached list
+// of nodes to avoid repeated API calls. It automatically updates the cache
+// when nodes are added, modified, or deleted.
+type NodeWatcher struct {
+	client kubernetes.Interface
+
+	nodeList      *v1.NodeList
+	nodeListMutex sync.RWMutex
+
+	watchRetryInterval time.Duration
+}
+
+// NewNodeWatcher creates a new NodeWatcher using the given kubeconfig.
+func NewNodeWatcher(kubeconfigPath string) (*NodeWatcher, error) {
+	clientConfig, err := utils.GetClientConfig("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &NodeWatcher{
+		client:             client,
+		nodeList:           &v1.NodeList{},
+		watchRetryInterval: defaultWatchRetryInterval,
+	}
+
+	return w, nil
+}
+
+// Run keeps watching the Nodes until the context is cancelled.
+// Any errors are logged and watching is re-established.
+func (w *NodeWatcher) Run(ctx context.Context) {
+	// Keep watching until the context is cancelled.
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		if err := w.watchNodes(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+
+			log.WithError(err).Warn("Node watcher failed")
+		}
+	}, w.watchRetryInterval)
+}
+
+func (w *NodeWatcher) watchNodes(ctx context.Context) error {
+	watchOpts := metav1.ListOptions{
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+	}
+	watchOpts.SendInitialEvents = ptr.To(true)
+
+	watcher, err := w.client.CoreV1().Nodes().Watch(ctx, watchOpts)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return nil
+			}
+
+			switch event.Type {
+			case watch.Added:
+				node := event.Object.(*v1.Node)
+				w.addOrUpdateNode(node)
+				log.WithFields(logrus.Fields{
+					"nodeName": node.Name,
+				}).Debug("Node added to cache")
+
+			case watch.Modified:
+				node := event.Object.(*v1.Node)
+				w.addOrUpdateNode(node)
+				log.WithFields(logrus.Fields{
+					"nodeName": node.Name,
+				}).Debug("Node updated in cache")
+
+			case watch.Deleted:
+				node := event.Object.(*v1.Node)
+				w.deleteNode(node)
+				log.WithFields(logrus.Fields{
+					"nodeName": node.Name,
+				}).Debug("Node removed from cache")
+
+			case watch.Bookmark:
+				// Bookmark events are used for tracking the resource version
+				// No action needed
+
+			case watch.Error:
+				log.WithFields(logrus.Fields{
+					"error": event.Object,
+				}).Warn("Watch error event received")
+				return nil
+			}
+
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (w *NodeWatcher) addOrUpdateNode(node *v1.Node) {
+	w.nodeListMutex.Lock()
+	defer w.nodeListMutex.Unlock()
+
+	// Check if node already exists
+	for i, existingNode := range w.nodeList.Items {
+		if existingNode.Name == node.Name {
+			// Update existing node
+			w.nodeList.Items[i] = *node
+			return
+		}
+	}
+
+	// Add new node
+	w.nodeList.Items = append(w.nodeList.Items, *node)
+}
+
+func (w *NodeWatcher) deleteNode(node *v1.Node) {
+	w.nodeListMutex.Lock()
+	defer w.nodeListMutex.Unlock()
+
+	// Find and remove the node
+	for i, existingNode := range w.nodeList.Items {
+		if existingNode.Name == node.Name {
+			w.nodeList.Items = append(w.nodeList.Items[:i], w.nodeList.Items[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetNodes returns a deep copy of the cached node list.
+func (w *NodeWatcher) GetNodes() *v1.NodeList {
+	w.nodeListMutex.RLock()
+	defer w.nodeListMutex.RUnlock()
+	return w.nodeList.DeepCopy()
+}
+
+// GetMasterNodes returns a deep copy of the cached node list filtered to only master nodes.
+func (w *NodeWatcher) GetMasterNodes() *v1.NodeList {
+	w.nodeListMutex.RLock()
+	defer w.nodeListMutex.RUnlock()
+
+	masterNodes := &v1.NodeList{}
+	for _, node := range w.nodeList.Items {
+		if _, ok := node.Labels["node-role.kubernetes.io/master"]; ok {
+			masterNodes.Items = append(masterNodes.Items, node)
+		}
+	}
+
+	return masterNodes
+}
+
+// GetNodeCount returns the current number of nodes in the cache.
+func (w *NodeWatcher) GetNodeCount() int {
+	w.nodeListMutex.RLock()
+	defer w.nodeListMutex.RUnlock()
+	return len(w.nodeList.Items)
+}

--- a/pkg/nodeconfig/watcher_test.go
+++ b/pkg/nodeconfig/watcher_test.go
@@ -1,0 +1,432 @@
+package nodeconfig
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var _ = Describe("NodeWatcher", func() {
+	var (
+		watcher       *NodeWatcher
+		fakeClientset *fake.Clientset
+		fakeWatcher   *watch.FakeWatcher
+		ctx           context.Context
+		cancel        context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		fakeClientset = fake.NewSimpleClientset()
+		fakeWatcher = watch.NewFake()
+
+		// Intercept watch requests and return our fake watcher
+		fakeClientset.PrependWatchReactor("nodes", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+			return true, fakeWatcher, nil
+		})
+
+		watcher = &NodeWatcher{
+			client:             fakeClientset,
+			nodeList:           &v1.NodeList{},
+			watchRetryInterval: 100 * time.Millisecond,
+		}
+
+		ctx, cancel = context.WithCancel(context.Background())
+	})
+
+	AfterEach(func() {
+		cancel()
+		if fakeWatcher != nil {
+			fakeWatcher.Stop()
+		}
+	})
+
+	Describe("GetNodes", func() {
+		Context("when the cache is empty", func() {
+			It("should return an empty node list", func() {
+				nodes := watcher.GetNodes()
+				Expect(nodes).NotTo(BeNil())
+				Expect(nodes.Items).To(HaveLen(0))
+			})
+		})
+
+		Context("when the cache has nodes", func() {
+			BeforeEach(func() {
+				watcher.nodeList.Items = []v1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				}
+			})
+
+			It("should return all nodes", func() {
+				nodes := watcher.GetNodes()
+				Expect(nodes.Items).To(HaveLen(2))
+				Expect(nodes.Items[0].Name).To(Equal("node1"))
+				Expect(nodes.Items[1].Name).To(Equal("node2"))
+			})
+
+			It("should return a deep copy", func() {
+				nodes := watcher.GetNodes()
+				nodes.Items[0].Name = "modified"
+				Expect(watcher.nodeList.Items[0].Name).To(Equal("node1"))
+			})
+		})
+	})
+
+	Describe("GetMasterNodes", func() {
+		BeforeEach(func() {
+			watcher.nodeList.Items = []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker1",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "master2",
+						Labels: map[string]string{
+							"node-role.kubernetes.io/master": "",
+						},
+					},
+				},
+			}
+		})
+
+		It("should return only master nodes", func() {
+			masters := watcher.GetMasterNodes()
+			Expect(masters.Items).To(HaveLen(2))
+			Expect(masters.Items[0].Name).To(Equal("master1"))
+			Expect(masters.Items[1].Name).To(Equal("master2"))
+		})
+
+		It("should not return worker nodes", func() {
+			masters := watcher.GetMasterNodes()
+			for _, node := range masters.Items {
+				Expect(node.Name).NotTo(Equal("worker1"))
+			}
+		})
+	})
+
+	Describe("GetNodeCount", func() {
+		Context("when cache is empty", func() {
+			It("should return 0", func() {
+				Expect(watcher.GetNodeCount()).To(Equal(0))
+			})
+		})
+
+		Context("when cache has nodes", func() {
+			BeforeEach(func() {
+				watcher.nodeList.Items = []v1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+				}
+			})
+
+			It("should return the correct count", func() {
+				Expect(watcher.GetNodeCount()).To(Equal(3))
+			})
+		})
+	})
+
+	Describe("addOrUpdateNode", func() {
+		It("should add a new node", func() {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "newnode"}}
+			watcher.addOrUpdateNode(node)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(1))
+			Expect(watcher.nodeList.Items[0].Name).To(Equal("newnode"))
+		})
+
+		It("should update an existing node", func() {
+			watcher.nodeList.Items = []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+					Status:     v1.NodeStatus{Phase: v1.NodePending},
+				},
+			}
+
+			updatedNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Status:     v1.NodeStatus{Phase: v1.NodeRunning},
+			}
+			watcher.addOrUpdateNode(updatedNode)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(1))
+			Expect(watcher.nodeList.Items[0].Status.Phase).To(Equal(v1.NodeRunning))
+		})
+
+		It("should maintain order when updating", func() {
+			watcher.nodeList.Items = []v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+			}
+
+			updatedNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+					Labels: map[string]string{
+						"updated": "true",
+					},
+				},
+			}
+			watcher.addOrUpdateNode(updatedNode)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(3))
+			Expect(watcher.nodeList.Items[1].Name).To(Equal("node2"))
+			Expect(watcher.nodeList.Items[1].Labels["updated"]).To(Equal("true"))
+		})
+	})
+
+	Describe("deleteNode", func() {
+		BeforeEach(func() {
+			watcher.nodeList.Items = []v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+			}
+		})
+
+		It("should delete an existing node", func() {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+			watcher.deleteNode(node)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(2))
+			Expect(watcher.nodeList.Items[0].Name).To(Equal("node1"))
+			Expect(watcher.nodeList.Items[1].Name).To(Equal("node3"))
+		})
+
+		It("should handle deleting non-existent node gracefully", func() {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nonexistent"}}
+			watcher.deleteNode(node)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(3))
+		})
+
+		It("should delete the first node", func() {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			watcher.deleteNode(node)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(2))
+			Expect(watcher.nodeList.Items[0].Name).To(Equal("node2"))
+		})
+
+		It("should delete the last node", func() {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3"}}
+			watcher.deleteNode(node)
+
+			Expect(watcher.nodeList.Items).To(HaveLen(2))
+			Expect(watcher.nodeList.Items[1].Name).To(Equal("node2"))
+		})
+	})
+
+	Describe("watchNodes integration", func() {
+		It("should handle Added events", func() {
+			go watcher.watchNodes(ctx)
+
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			fakeWatcher.Add(node)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(1))
+
+			nodes := watcher.GetNodes()
+			Expect(nodes.Items[0].Name).To(Equal("node1"))
+		})
+
+		It("should handle Modified events", func() {
+			go watcher.watchNodes(ctx)
+
+			// Add initial node
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Status:     v1.NodeStatus{Phase: v1.NodePending},
+			}
+			fakeWatcher.Add(node)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(1))
+
+			// Modify the node
+			modifiedNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Status:     v1.NodeStatus{Phase: v1.NodeRunning},
+			}
+			fakeWatcher.Modify(modifiedNode)
+
+			Eventually(func() v1.NodePhase {
+				nodes := watcher.GetNodes()
+				if len(nodes.Items) > 0 {
+					return nodes.Items[0].Status.Phase
+				}
+				return ""
+			}, time.Second*2, time.Millisecond*100).Should(Equal(v1.NodeRunning))
+		})
+
+		It("should handle Deleted events", func() {
+			go watcher.watchNodes(ctx)
+
+			// Add nodes
+			node1 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			node2 := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+			fakeWatcher.Add(node1)
+			fakeWatcher.Add(node2)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(2))
+
+			// Delete one node
+			fakeWatcher.Delete(node1)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(1))
+
+			nodes := watcher.GetNodes()
+			Expect(nodes.Items[0].Name).To(Equal("node2"))
+		})
+
+		It("should handle multiple rapid events", func() {
+			go watcher.watchNodes(ctx)
+
+			// Rapidly add multiple nodes
+			for i := 0; i < 10; i++ {
+				node := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node" + string(rune('0'+i)),
+					},
+				}
+				fakeWatcher.Add(node)
+			}
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(10))
+		})
+
+		It("should handle Bookmark events without error", func() {
+			go watcher.watchNodes(ctx)
+
+			// Send bookmark event (shouldn't cause issues)
+			fakeWatcher.Action(watch.Bookmark, &v1.Node{})
+
+			// Add a real node to verify watcher still works
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			fakeWatcher.Add(node)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(1))
+		})
+
+		It("should stop watching when context is cancelled", func() {
+			localCtx, localCancel := context.WithCancel(ctx)
+
+			done := make(chan bool)
+			go func() {
+				watcher.watchNodes(localCtx)
+				done <- true
+			}()
+
+			// Add a node
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			fakeWatcher.Add(node)
+
+			Eventually(func() int {
+				return watcher.GetNodeCount()
+			}, time.Second*2, time.Millisecond*100).Should(Equal(1))
+
+			// Cancel context
+			localCancel()
+
+			// Verify watchNodes exits
+			Eventually(done, time.Second*2).Should(Receive())
+		})
+	})
+
+	Describe("Thread safety", func() {
+		It("should handle concurrent reads and writes", func() {
+			go watcher.watchNodes(ctx)
+
+			done := make(chan bool)
+
+			// Concurrent writes
+			go func() {
+				defer func() { done <- true }()
+				for i := 0; i < 50; i++ {
+					node := &v1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node" + string(rune('0'+i%10)),
+						},
+					}
+					fakeWatcher.Add(node)
+					time.Sleep(2 * time.Millisecond)
+				}
+			}()
+
+			// Concurrent reads
+			for i := 0; i < 50; i++ {
+				go func() {
+					_ = watcher.GetNodes()
+					_ = watcher.GetMasterNodes()
+					_ = watcher.GetNodeCount()
+				}()
+			}
+
+			// Wait for writes to complete
+			Eventually(done, time.Second*3).Should(Receive())
+
+			// Should not panic and should have nodes
+			Expect(watcher.GetNodeCount()).To(BeNumerically(">", 0))
+		})
+	})
+})
+
+var _ = Describe("NodeCacheGetter Interface Compliance", func() {
+	It("should implement all NodeCacheGetter methods", func() {
+		fakeClientset := fake.NewSimpleClientset()
+		watcher := &NodeWatcher{
+			client:             fakeClientset,
+			nodeList:           &v1.NodeList{},
+			watchRetryInterval: 100 * time.Millisecond,
+		}
+
+		// Verify the watcher implements the interface
+		var _ interface {
+			GetNodes() *v1.NodeList
+			GetMasterNodes() *v1.NodeList
+			GetNodeCount() int
+		} = watcher
+
+		// Verify methods work
+		nodes := watcher.GetNodes()
+		Expect(nodes).NotTo(BeNil())
+
+		masters := watcher.GetMasterNodes()
+		Expect(masters).NotTo(BeNil())
+
+		count := watcher.GetNodeCount()
+		Expect(count).To(Equal(0))
+	})
+})


### PR DESCRIPTION
Replace frequent node LIST calls with a watch-based cache in monitor loops.
Implements NodeWatcher similar to existing loggingconfig watcher pattern.

- Add pkg/nodeconfig with NodeWatcher and NodeCacheGetter interface
- Refactor node retrieval functions to use cache when available
- Update monitors (dynkeepalived, coredns) to use NodeWatcher
- Reduce API calls from hundreds/min to single watch connection
- Maintain backward compatibility with nil cache fallback

Fixes: OCPBUGS-42805