### PR TITLE
WIP: OCPBUGS-82500: Improve handling of multiple Load Balancer IP addresses for Cloud platforms

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -969,18 +969,30 @@ func updateNodewithCloudInfo(apiLBIP, apiIntLBIP, ingressIP net.IP, resolvConfPa
 }
 
 func PopulateCloudLBIPAddresses(clusterLBConfig ClusterLBConfig, node Node) (updatedNode Node, err error) {
+	// Track if we encounter any IPv6 addresses
+	hasIPv6 := false
 	for _, ip := range clusterLBConfig.ApiIntLBIPs {
 		node.Cluster.APIIntLBIPs = append(node.Cluster.APIIntLBIPs, ip.String())
+		if ip.To4() == nil {
+			hasIPv6 = true
+		}
 	}
 	for _, ip := range clusterLBConfig.ApiLBIPs {
 		node.Cluster.APILBIPs = append(node.Cluster.APILBIPs, ip.String())
+		if ip.To4() == nil {
+			hasIPv6 = true
+		}
 	}
 	for _, ip := range clusterLBConfig.IngressLBIPs {
 		node.Cluster.IngressLBIPs = append(node.Cluster.IngressLBIPs, ip.String())
+		if ip.To4() == nil {
+			hasIPv6 = true
+		}
 	}
+	// Set record types based on whether we have IPv6
 	node.Cluster.CloudLBRecordType = "A"
 	node.Cluster.CloudLBEmptyType = "AAAA"
-	if len(clusterLBConfig.ApiIntLBIPs) > 0 && clusterLBConfig.ApiIntLBIPs[0].To4() == nil {
+	if hasIPv6 {
 		node.Cluster.CloudLBRecordType = "AAAA"
 		node.Cluster.CloudLBEmptyType = "A"
 	}

--- a/pkg/config/node_test.go
+++ b/pkg/config/node_test.go
@@ -204,14 +204,26 @@ var (
 	testApiIntLBIPv4      = net.ParseIP("10.10.10.20")
 	testIngressOneIPv4    = net.ParseIP("192.168.20.140")
 	testIngressTwoIPv4    = net.ParseIP("10.10.10.40")
+	testApiLBIPv6         = net.ParseIP("2001:db8::1")
+	testApiIntLBIPv6      = net.ParseIP("2001:db8::2")
+	testIngressOneIPv6    = net.ParseIP("2001:db8::3")
+	testIngressTwoIPv6    = net.ParseIP("2001:db8::4")
 	testClusterLBConfig   = ClusterLBConfig{
 		ApiLBIPs:     []net.IP{testApiLBIPv4},
 		ApiIntLBIPs:  []net.IP{testApiIntLBIPv4},
 		IngressLBIPs: []net.IP{testIngressOneIPv4, testIngressTwoIPv4}}
+	testClusterLBConfigIPv6 = ClusterLBConfig{
+		ApiLBIPs:     []net.IP{testApiLBIPv6},
+		ApiIntLBIPs:  []net.IP{testApiIntLBIPv6},
+		IngressLBIPs: []net.IP{testIngressOneIPv6, testIngressTwoIPv6}}
 	expectedApiLBIPv4      = "192.168.0.111"
 	expectedApiIntLBIPv4   = "10.10.10.20"
 	expectedIngressOneIPv4 = "192.168.20.140"
 	expectedIngressTwoIPv4 = "10.10.10.40"
+	expectedApiLBIPv6      = "2001:db8::1"
+	expectedApiIntLBIPv6   = "2001:db8::2"
+	expectedIngressOneIPv6 = "2001:db8::3"
+	expectedIngressTwoIPv6 = "2001:db8::4"
 
 	emptyLBIPs = []net.IP{}
 )
@@ -282,6 +294,45 @@ var _ = Describe("PopulateCloudLBIPAddresses", func() {
 				Expect(len(newNode.Cluster.IngressLBIPs)).To(Equal(len(emptyLBIPs)))
 				Expect(newNode.Cluster.CloudLBRecordType).To(Equal("A"))
 				Expect(err).To(BeNil())
+			})
+		})
+		Context("for IPV6 Cloud LB IPs", func() {
+			Context("with multiple Ingress LB IPs", func() {
+				It("matches IPv6 API and Ingress LB IPs", func() {
+					newNode := Node{}
+					newNode, err := PopulateCloudLBIPAddresses(testClusterLBConfigIPv6, newNode)
+					Expect(newNode.Cluster.APILBIPs[0]).To(Equal(expectedApiLBIPv6))
+					Expect(newNode.Cluster.IngressLBIPs[1]).To(Equal(expectedIngressTwoIPv6))
+					Expect(newNode.Cluster.CloudLBRecordType).To(Equal("AAAA"))
+					Expect(newNode.Cluster.CloudLBEmptyType).To(Equal("A"))
+					Expect(err).To(BeNil())
+				})
+				It("handles mixed IPv4 in API and IPv6 in Ingress", func() {
+					newNode := Node{}
+					mixedLBConfig := ClusterLBConfig{
+						ApiLBIPs:     []net.IP{testApiLBIPv4},
+						ApiIntLBIPs:  []net.IP{testApiIntLBIPv4},
+						IngressLBIPs: []net.IP{testIngressOneIPv6}}
+					newNode, err := PopulateCloudLBIPAddresses(mixedLBConfig, newNode)
+					Expect(newNode.Cluster.APILBIPs[0]).To(Equal(expectedApiLBIPv4))
+					Expect(newNode.Cluster.IngressLBIPs[0]).To(Equal(expectedIngressOneIPv6))
+					Expect(newNode.Cluster.CloudLBRecordType).To(Equal("AAAA"))
+					Expect(newNode.Cluster.CloudLBEmptyType).To(Equal("A"))
+					Expect(err).To(BeNil())
+				})
+				It("handles mixed IPv6 in API and IPv4 in Ingress", func() {
+					newNode := Node{}
+					mixedLBConfig := ClusterLBConfig{
+						ApiLBIPs:     []net.IP{testApiLBIPv6},
+						ApiIntLBIPs:  []net.IP{testApiIntLBIPv6},
+						IngressLBIPs: []net.IP{testIngressOneIPv4}}
+					newNode, err := PopulateCloudLBIPAddresses(mixedLBConfig, newNode)
+					Expect(newNode.Cluster.APILBIPs[0]).To(Equal(expectedApiLBIPv6))
+					Expect(newNode.Cluster.IngressLBIPs[0]).To(Equal(expectedIngressOneIPv4))
+					Expect(newNode.Cluster.CloudLBRecordType).To(Equal("AAAA"))
+					Expect(newNode.Cluster.CloudLBEmptyType).To(Equal("A"))
+					Expect(err).To(BeNil())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
In the case of Cloud platforms, there could be multiple IPv4 and IPv6 addresses for each Load Balancer to achieve HA. Removed assumption that the 2nd IP address is always going to be an IPv6 address and added a check to ascertain that.

Partially fixes: https://redhat.atlassian.net/browse/OCPBUGS-82500