### PR TITLE
NO-ISSUE: Bump go to fix security vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/baremetal-runtimecfg
 
-go 1.24.0
-
-toolchain go1.24.6
+go 1.25.8
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
We should be using go 1.25 anyway in this release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit Go toolchain directive and updated the project's declared Go version to 1.25.8 to ensure consistent builds and toolchain compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->