### PR TITLE
OPNET-785: Add FRR peer-file rendering for BGP-based VIP management

### DIFF
--- a/cmd/runtimecfg/render.go
+++ b/cmd/runtimecfg/render.go
@@ -36,6 +36,7 @@ func init() {
 	renderCmd.Flags().IPSlice("cloud-int-lb-ips", nil, "IP Addresses of Cloud Internal Load Balancers for OpenShift Internal API")
 	renderCmd.Flags().IPSlice("cloud-ingress-lb-ips", nil, "IP Addresses of Cloud Ingress Load Balancers")
 	renderCmd.Flags().StringP("platform", "p", "", "Cluster Platform")
+	renderCmd.Flags().String("peer-file", "", "Path to frr-peers.json for FRR config rendering. When set, templates receive FRR-specific data (Hostname, RouterID, LocalASN, Peers, Communities) instead of the standard Node struct.")
 	rootCmd.AddCommand(renderCmd)
 }
 
@@ -110,7 +111,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 	}
 
 	clusterLBConfig := config.ClusterLBConfig{ApiLBIPs: apiLBIPs, ApiIntLBIPs: apiIntLBIPs, IngressLBIPs: ingressLBIPs}
-	config, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType, "")
+	cfg, err := config.GetConfig(kubeCfgPath, clusterConfigPath, resolveConfPath, apiVips, ingressVips, apiPort, lbPort, statPort, clusterLBConfig, platformType, "")
 	if err != nil {
 		return err
 	}
@@ -127,5 +128,16 @@ func runRender(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return render.Render(outDir, args[1:], config)
+	// Check if FRR peer file is provided for FRR config rendering
+	peerFilePath, _ := cmd.Flags().GetString("peer-file")
+	if peerFilePath != "" {
+		peerMapping, err := config.LoadFRRPeerMapping(peerFilePath)
+		if err != nil {
+			return err
+		}
+		frrConfig := config.BuildFRRRenderConfig(cfg, peerMapping)
+		return render.Render(outDir, args[1:], frrConfig)
+	}
+
+	return render.Render(outDir, args[1:], cfg)
 }

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -99,6 +99,36 @@ type ClusterLBConfig struct {
 	IngressLBIPs []net.IP
 }
 
+// FRRPeer defines a BGP peer for FRR configuration rendering.
+type FRRPeer struct {
+	PeerAddress   string `json:"peerAddress"`
+	PeerASN       int64  `json:"peerASN"`
+	Password      string `json:"password,omitempty"`
+	BFDEnabled    string `json:"bfdEnabled,omitempty"`
+	EBGPMultiHop  string `json:"ebgpMultiHop,omitempty"`
+	HoldTime      string `json:"holdTime,omitempty"`
+	KeepaliveTime string `json:"keepaliveTime,omitempty"`
+}
+
+// FRRPeerMapping represents the per-node BGP peer mapping file (frr-peers.json).
+// It contains a default peer list and optional per-host overrides keyed by hostname.
+type FRRPeerMapping struct {
+	LocalASN      int64                `json:"localASN"`
+	DefaultPeers  []FRRPeer            `json:"defaultPeers"`
+	HostOverrides map[string][]FRRPeer `json:"hostOverrides,omitempty"`
+	Communities   []string             `json:"communities,omitempty"`
+}
+
+// FRRRenderConfig is the template data context for rendering frr.conf.
+// Field names match what the frr.conf.tmpl template expects.
+type FRRRenderConfig struct {
+	Hostname    string
+	RouterID    string
+	LocalASN    int64
+	Peers       []FRRPeer
+	Communities []string
+}
+
 func getDNSUpstreams(resolvConfPath string) (upstreams []string, err error) {
 	dnsFile, err := os.Open(resolvConfPath)
 	if err != nil {
@@ -985,4 +1015,38 @@ func PopulateCloudLBIPAddresses(clusterLBConfig ClusterLBConfig, node Node) (upd
 		node.Cluster.CloudLBEmptyType = "A"
 	}
 	return node, nil
+}
+
+// LoadFRRPeerMapping reads a frr-peers.json file and returns the parsed mapping.
+func LoadFRRPeerMapping(path string) (*FRRPeerMapping, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read peer mapping file %s: %v", path, err)
+	}
+	var mapping FRRPeerMapping
+	if err := json.Unmarshal(data, &mapping); err != nil {
+		return nil, fmt.Errorf("failed to parse peer mapping file %s: %v", path, err)
+	}
+	return &mapping, nil
+}
+
+// ResolveFRRPeers returns the BGP peers for the given hostname.
+// If a host-specific override exists, it is used; otherwise the default peers are returned.
+func (m *FRRPeerMapping) ResolveFRRPeers(hostname string) []FRRPeer {
+	if peers, ok := m.HostOverrides[hostname]; ok {
+		return peers
+	}
+	return m.DefaultPeers
+}
+
+// BuildFRRRenderConfig creates the template data context for FRR config rendering
+// from a Node and peer mapping.
+func BuildFRRRenderConfig(node Node, mapping *FRRPeerMapping) FRRRenderConfig {
+	return FRRRenderConfig{
+		Hostname:    node.ShortHostname,
+		RouterID:    node.NonVirtualIP,
+		LocalASN:    mapping.LocalASN,
+		Peers:       mapping.ResolveFRRPeers(node.ShortHostname),
+		Communities: mapping.Communities,
+	}
 }

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -101,11 +101,16 @@ type ClusterLBConfig struct {
 
 // FRRPeer defines a BGP peer for FRR configuration rendering.
 type FRRPeer struct {
-	PeerAddress   string `json:"peerAddress"`
-	PeerASN       int64  `json:"peerASN"`
-	Password      string `json:"password,omitempty"`
-	BFDEnabled    string `json:"bfdEnabled,omitempty"`
-	EBGPMultiHop  string `json:"ebgpMultiHop,omitempty"`
+	PeerAddress string `json:"peerAddress"`
+	PeerASN     int64  `json:"peerASN"`
+	Password    string `json:"password,omitempty"`
+	// Port is the BGP session TCP port; 0 means the default (179).
+	Port         int32  `json:"port,omitempty"`
+	BFDEnabled   string `json:"bfdEnabled,omitempty"`
+	EBGPMultiHop string `json:"ebgpMultiHop,omitempty"`
+	// HoldTime and KeepaliveTime are whole seconds as decimal strings
+	// (e.g. "90"), matching FRR's "timers <keepalive> <hold>" syntax.
+	// Producers must set both or neither.
 	HoldTime      string `json:"holdTime,omitempty"`
 	KeepaliveTime string `json:"keepaliveTime,omitempty"`
 }

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -3,8 +3,10 @@ package render
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -18,7 +20,18 @@ var extLen = len(ext)
 var log = logrus.New()
 
 func RenderFile(renderPath, templatePath string, cfg interface{}) error {
-	tmpl, err := template.ParseFiles(templatePath)
+	funcMap := template.FuncMap{
+		"isIPv4": func(addr string) bool {
+			ip := net.ParseIP(addr)
+			return ip != nil && ip.To4() != nil
+		},
+		"isIPv6": func(addr string) bool {
+			ip := net.ParseIP(addr)
+			return ip != nil && ip.To4() == nil
+		},
+	}
+	name := filepath.Base(templatePath)
+	tmpl, err := template.New(name).Funcs(funcMap).ParseFiles(templatePath)
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"path": templatePath,


### PR DESCRIPTION
## What

Adds `runtimecfg render --peer-file` support for rendering FRR configuration from a JSON peer mapping, consumed by the frr-k8s static pod introduced by BGP-based VIP management (openshift/enhancements#1982):

- **FRR peer types + resolution** (`FRRPeerMapping`: `localASN`, `defaultPeers`, `hostOverrides` keyed by short hostname, `communities`): per-node peer list resolution — hosts with an override use it, everything else falls back to the defaults. This is the two-phase rendering pattern keepalived uses today (identical file delivered to all nodes by MCO; node-specific config rendered locally at pod start).
- **`--peer-file` flag on `render`**: when set, templates receive FRR-specific data (`.Hostname`, `.RouterID`, `.LocalASN`, `.Peers`, `.Communities`) instead of the standard Node struct. Works without a live API server (bootstrap-safe): cluster name/domain parse locally and the router-id comes from the node's non-virtual IP.
- **`isIPv4`/`isIPv6` template functions** for address-family-aware FRR templates.

The peer-file schema is shared verbatim with the installer-generated `bgp-vip-config` ConfigMap (extra keys are ignored), so one schema flows from install-config to the node.

## Validation

Consumed end to end by the reference implementation of enhancement 1982 across 14 dev-scripts baremetal installs (bootstrap + day-2 rendering on all control plane nodes): https://github.com/mkowalski/bgp-vip-demo. Unit tests included; `go test ./...` green.

Part of OPNET-595; this repo's subtask: [OPNET-785](https://issues.redhat.com/browse/OPNET-785).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional FRR peer mapping support for render operations through a peer configuration file.
  - Supports default peer settings with host-specific overrides.
  - FRR output now includes the appropriate hostname, router ID, peers, and communities.
  - Added IPv4 and IPv6 classification support for templates.

- **Bug Fixes**
  - Improved template rendering for IPv4 and IPv6 address classification.
  - Standard rendering behavior remains unchanged when no FRR peer file is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->