### PR TITLE
OCPBUGS-99496: Detect bootstrap apiserver shutdown via /readyz

### DIFF
--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -62,6 +63,15 @@ func getActualMode(cfgPath string) (error, bool) {
 	return nil, enableUnicast
 }
 
+// kubeApiReadyzClient is shared across probe calls so TLS connections can be
+// reused instead of performing a new handshake every second.
+var kubeApiReadyzClient = &http.Client{
+	Timeout: 5 * time.Second,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
 // isKubeApiHealthy probes the /readyz endpoint of the local kube-apiserver.
 // Unlike a data plane request (e.g. listing nodes), /readyz starts returning
 // 500 the moment the apiserver begins its graceful shutdown, which lets us
@@ -70,18 +80,13 @@ func getActualMode(cfgPath string) (error, bool) {
 // local endpoint, not its identity (same approach as the keepalived check
 // scripts that curl -k the endpoint).
 func isKubeApiHealthy(apiPort uint16) bool {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/readyz", apiPort))
+	resp, err := kubeApiReadyzClient.Get(fmt.Sprintf("https://localhost:%d/readyz", apiPort))
 	if err != nil {
 		log.WithError(err).Info("isKubeApiHealthy: readyz probe failed")
 		return false
 	}
 	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.StatusCode == http.StatusOK
 }
 

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -59,6 +60,29 @@ func getActualMode(cfgPath string) (error, bool) {
 		enableUnicast = true
 	}
 	return nil, enableUnicast
+}
+
+// isKubeApiHealthy probes the /readyz endpoint of the local kube-apiserver.
+// Unlike a data plane request (e.g. listing nodes), /readyz starts returning
+// 500 the moment the apiserver begins its graceful shutdown, which lets us
+// detect bootstrap teardown within seconds instead of minutes (OCPBUGS-99496).
+// TLS verification is disabled because we only care about readiness of the
+// local endpoint, not its identity (same approach as the keepalived check
+// scripts that curl -k the endpoint).
+func isKubeApiHealthy(apiPort uint16) bool {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/readyz", apiPort))
+	if err != nil {
+		log.WithError(err).Info("isKubeApiHealthy: readyz probe failed")
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }
 
 func updateUnicastConfig(kubeconfigPath string, newConfig *config.Node, nodeCache config.NodeCacheGetter) error {

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -72,6 +72,12 @@ var kubeApiReadyzClient = &http.Client{
 	},
 }
 
+// ironicProbeClient bounds the Ironic liveness probe so a hung endpoint
+// cannot stall the bootstrap monitoring loop indefinitely.
+var ironicProbeClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
+
 // isKubeApiHealthy probes the /readyz endpoint of the local kube-apiserver.
 // Unlike a data plane request (e.g. listing nodes), /readyz starts returning
 // 500 the moment the apiserver begins its graceful shutdown, which lets us
@@ -82,7 +88,7 @@ var kubeApiReadyzClient = &http.Client{
 func isKubeApiHealthy(apiPort uint16) bool {
 	resp, err := kubeApiReadyzClient.Get(fmt.Sprintf("https://localhost:%d/readyz", apiPort))
 	if err != nil {
-		log.WithError(err).Info("isKubeApiHealthy: readyz probe failed")
+		log.WithError(err).Debug("isKubeApiHealthy: readyz probe failed")
 		return false
 	}
 	defer resp.Body.Close()
@@ -200,11 +206,14 @@ func handleBootstrapStopKeepalived(apiPort uint16, bootstrapStopKeepalived chan 
 			// We have started to talk to Ironic through the API VIP as well,
 			// so if Ironic is still up then we need to keep the VIP, even if
 			// the apiserver has gone down.
-			if _, err := http.Get("http://localhost:6385/v1"); err != nil {
+			if resp, err := ironicProbeClient.Get("http://localhost:6385/v1"); err != nil {
 				consecutiveErr++
 				log.WithFields(logrus.Fields{
 					"consecutiveErr": consecutiveErr,
 				}).Info("handleBootstrapStopKeepalived: detect failure on API and Ironic")
+			} else {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
 			}
 		} else {
 			if consecutiveErr > bootstrapApiFailuresThreshold { // Means it was stopped

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -177,7 +177,7 @@ func isModeUpdateNeeded(cfgPath string) (bool, modeUpdateInfo) {
 	return updateRequired, desiredModeInfo
 }
 
-func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalived chan APIState, nodeCache config.NodeCacheGetter) {
+func handleBootstrapStopKeepalived(apiPort uint16, bootstrapStopKeepalived chan APIState) {
 	consecutiveErr := 0
 
 	/* It should take up to ~20 seconds for the local kube-apiserver to start running on the
@@ -187,7 +187,7 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	*/
 	log.Info("handleBootstrapStopKeepalived: verify first that local kube-apiserver is operational")
 	for start := time.Now(); time.Since(start) < time.Minute*30; {
-		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}, nodeCache); err == nil {
+		if isKubeApiHealthy(apiPort) {
 			log.Info("handleBootstrapStopKeepalived: local kube-apiserver is operational")
 			break
 		}
@@ -196,11 +196,11 @@ func handleBootstrapStopKeepalived(kubeconfigPath string, bootstrapStopKeepalive
 	}
 
 	for {
-		if _, err := config.GetIngressConfig(kubeconfigPath, []string{}, nodeCache); err != nil {
+		if !isKubeApiHealthy(apiPort) {
 			// We have started to talk to Ironic through the API VIP as well,
 			// so if Ironic is still up then we need to keep the VIP, even if
 			// the apiserver has gone down.
-			if _, err = http.Get("http://localhost:6385/v1"); err != nil {
+			if _, err := http.Get("http://localhost:6385/v1"); err != nil {
 				consecutiveErr++
 				log.WithFields(logrus.Fields{
 					"consecutiveErr": consecutiveErr,
@@ -311,8 +311,7 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		   so, Keepalived on bootstrap should stop running when local kube-apiserver isn't operational anymore.
 		   handleBootstrapStopKeepalived function is responsible to stop Keepalived when the condition is met. */
 
-		// Additionally, on bootstrap we don't care about caching the nodes because we don't need performance optimizations.
-		go handleBootstrapStopKeepalived(kubeconfigPath, bootstrapStopKeepalived, nil)
+		go handleBootstrapStopKeepalived(apiPort, bootstrapStopKeepalived)
 	}
 
 	conn, err := net.Dial("unix", keepalivedControlSock)

--- a/pkg/monitor/dynkeepalived_test.go
+++ b/pkg/monitor/dynkeepalived_test.go
@@ -1,0 +1,67 @@
+package monitor
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// startTLSServer starts a TLS server returning the given status code and
+// returns the port it listens on plus a cleanup function.
+func startTLSServer(t *testing.T, statusCode int) (uint16, func()) {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/readyz" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(statusCode)
+	}))
+	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse test server address: %v", err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		t.Fatalf("failed to parse test server port: %v", err)
+	}
+	return uint16(port), srv.Close
+}
+
+func TestIsKubeApiHealthyReturns200(t *testing.T) {
+	port, cleanup := startTLSServer(t, http.StatusOK)
+	defer cleanup()
+	if !isKubeApiHealthy(port) {
+		t.Error("expected healthy for /readyz returning 200")
+	}
+}
+
+func TestIsKubeApiHealthyReturns500(t *testing.T) {
+	port, cleanup := startTLSServer(t, http.StatusInternalServerError)
+	defer cleanup()
+	if isKubeApiHealthy(port) {
+		t.Error("expected unhealthy for /readyz returning 500")
+	}
+}
+
+func TestIsKubeApiHealthyConnectionRefused(t *testing.T) {
+	// Grab a free port and close the listener so connections are refused.
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse address: %v", err)
+	}
+	l.Close()
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+	if isKubeApiHealthy(uint16(port)) {
+		t.Error("expected unhealthy when connection is refused")
+	}
+}

--- a/pkg/monitor/dynkeepalived_test.go
+++ b/pkg/monitor/dynkeepalived_test.go
@@ -5,13 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// startTLSServer starts a TLS server returning the given status code and
-// returns the port it listens on plus a cleanup function.
-func startTLSServer(t *testing.T, statusCode int) (uint16, func()) {
-	t.Helper()
+// startTLSServer starts a TLS server returning the given status code on
+// /readyz and returns the port it listens on plus a cleanup function.
+func startTLSServer(statusCode int) (uint16, func()) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/readyz" {
 			w.WriteHeader(http.StatusNotFound)
@@ -20,48 +21,34 @@ func startTLSServer(t *testing.T, statusCode int) (uint16, func()) {
 		w.WriteHeader(statusCode)
 	}))
 	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
-	if err != nil {
-		t.Fatalf("failed to parse test server address: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		t.Fatalf("failed to parse test server port: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	return uint16(port), srv.Close
 }
 
-func TestIsKubeApiHealthyReturns200(t *testing.T) {
-	port, cleanup := startTLSServer(t, http.StatusOK)
-	defer cleanup()
-	if !isKubeApiHealthy(port) {
-		t.Error("expected healthy for /readyz returning 200")
-	}
-}
+var _ = Describe("isKubeApiHealthy", func() {
+	It("reports healthy when /readyz returns 200", func() {
+		port, cleanup := startTLSServer(http.StatusOK)
+		defer cleanup()
+		Expect(isKubeApiHealthy(port)).To(BeTrue())
+	})
 
-func TestIsKubeApiHealthyReturns500(t *testing.T) {
-	port, cleanup := startTLSServer(t, http.StatusInternalServerError)
-	defer cleanup()
-	if isKubeApiHealthy(port) {
-		t.Error("expected unhealthy for /readyz returning 500")
-	}
-}
+	It("reports unhealthy when /readyz returns 500", func() {
+		port, cleanup := startTLSServer(http.StatusInternalServerError)
+		defer cleanup()
+		Expect(isKubeApiHealthy(port)).To(BeFalse())
+	})
 
-func TestIsKubeApiHealthyConnectionRefused(t *testing.T) {
-	// Grab a free port and close the listener so connections are refused.
-	l, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
-	_, portStr, err := net.SplitHostPort(l.Addr().String())
-	if err != nil {
-		t.Fatalf("failed to parse address: %v", err)
-	}
-	l.Close()
-	port, err := strconv.ParseUint(portStr, 10, 16)
-	if err != nil {
-		t.Fatalf("failed to parse port: %v", err)
-	}
-	if isKubeApiHealthy(uint16(port)) {
-		t.Error("expected unhealthy when connection is refused")
-	}
-}
+	It("reports unhealthy when the connection is refused", func() {
+		// Grab a free port and close the listener so connections are refused.
+		l, err := net.Listen("tcp", "localhost:0")
+		Expect(err).NotTo(HaveOccurred())
+		_, portStr, err := net.SplitHostPort(l.Addr().String())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(l.Close()).To(Succeed())
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isKubeApiHealthy(uint16(port))).To(BeFalse())
+	})
+})

--- a/pkg/monitor/monitor_suite_test.go
+++ b/pkg/monitor/monitor_suite_test.go
@@ -1,0 +1,13 @@
+package monitor
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMonitor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Monitor Suite")
+}


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-99496](https://issues.redhat.com/browse/OCPBUGS-99496): LateConnections failures of `[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests` on metal IPI (IPv4/IPv6/dualstack).

- `handleBootstrapStopKeepalived` previously detected the bootstrap kube-apiserver's death via `GetIngressConfig()`, a `Nodes().List()` data plane call. During graceful shutdown the apiserver keeps serving data plane requests for 70s (`AfterShutdownDelayDuration`), and afterwards two consecutive 30s client timeouts had to elapse — delaying the API VIP transition off the bootstrap by ~2m20s. During that window OVN's EndpointSlice watch via the VIP is disrupted, leaving stale LB rules that route new connections to control plane apiservers restarting mid-install, producing LateConnections events.
- Probe `https://localhost:<apiPort>/readyz` instead: it returns 500 as soon as shutdown is initiated, so keepalived now stops ~5s after bootstrap teardown begins. The Ironic guard and failure threshold are unchanged.
- Adds unit tests for the new probe helper (200 / 500 / connection refused).

## Test Plan
- [x] `go build ./...`, `go vet ./pkg/monitor/`, `go test ./...`
- [ ] e2e-metal-ipi-ovn IPv4/IPv6/dualstack CI jobs: verify VIP transition delay drops to seconds and LateConnections failures disappear

---
This PR was generated using AI. Please verify before acting on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap keepalived shutdown handling by checking the local Kubernetes apiserver `/readyz` endpoint for readiness over HTTPS.
  * Health detection is now more reliable, and it cleanly falls back to probing Ironic when the apiserver is not healthy.
* **Tests**
  * Added Ginkgo/Gomega coverage for apiserver readiness probing: healthy (200), unhealthy (500), and connection-refused scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->