### PR TITLE
OCPBUGS-109633: Resign VIPs when the node shuts down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config
 - Manages Virtual IP configurations for API and Ingress
 - Supports different control plane topologies
 - Handles multiple VIPs
+- On SIGTERM, if the host itself is shutting down (not just the pod restarting), makes sure no VIP stays configured on the node: requests a clean keepalived stop and force-removes the VIPs as a fallback, so client traffic cannot be routed to the local draining kube-apiserver (OCPBUGS-109633)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ dynkeepalived path_to_kubeconfig path_to_keepalived_cfg_template path_to_config
 - Manages Virtual IP configurations for API and Ingress
 - Supports different control plane topologies
 - Handles multiple VIPs
-- On SIGTERM, if the host itself is shutting down (not just the pod restarting), makes sure no VIP stays configured on the node: requests a clean keepalived stop and force-removes the VIPs as a fallback, so client traffic cannot be routed to the local draining kube-apiserver (OCPBUGS-109633)
+- On host shutdown (not mere pod restart), ensures no VIP stays configured: requests a clean keepalived stop, force-removes the VIPs as a fallback (OCPBUGS-109633)
 
 ---
 

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -331,6 +331,10 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 	for {
 		select {
 		case <-ctx.Done():
+			// The node may be rebooting/shutting down: make sure no
+			// stale VIP survives into the shutdown window
+			// (OCPBUGS-109633). No-op if only the pod is restarting.
+			handleShutdownResign(conn, append(append([]net.IP{}, apiVips...), ingressVips...))
 			return nil
 
 		case APIStateChanged := <-bootstrapStopKeepalived:

--- a/pkg/monitor/dynkeepalived.go
+++ b/pkg/monitor/dynkeepalived.go
@@ -328,13 +328,16 @@ func KeepalivedWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath st
 		return err
 	}
 	defer conn.Close()
+	// The node may be rebooting/shutting down when this function exits -
+	// whether via SIGTERM (ctx.Done) or an error return, e.g. the draining
+	// apiserver failing a config fetch. Make sure no stale VIP survives
+	// into the shutdown window (OCPBUGS-109633). This is a no-op unless the
+	// host itself is shutting down, so ordinary pod restarts and runtime
+	// errors on a healthy node never touch the VIPs.
+	defer handleShutdownResign(conn, append(append([]net.IP{}, apiVips...), ingressVips...))
 	for {
 		select {
 		case <-ctx.Done():
-			// The node may be rebooting/shutting down: make sure no
-			// stale VIP survives into the shutdown window
-			// (OCPBUGS-109633). No-op if only the pod is restarting.
-			handleShutdownResign(conn, append(append([]net.IP{}, apiVips...), ingressVips...))
 			return nil
 
 		case APIStateChanged := <-bootstrapStopKeepalived:

--- a/pkg/monitor/shutdownresign_linux.go
+++ b/pkg/monitor/shutdownresign_linux.go
@@ -3,6 +3,7 @@
 package monitor
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os/exec"
@@ -24,11 +25,16 @@ var (
 	// is still alive in MASTER state it monitors its VIPs via netlink and
 	// re-adds any address deleted out from under it, so removal is retried
 	// until keepalived is gone or the node has finished shutting down the
-	// containers. This must stay below the pod termination grace period
-	// (65s) so we never block pod shutdown.
+	// containers. Together with resignStopWait this must stay below the
+	// keepalived pod's deletionGracePeriodSeconds (65s, see the keepalived
+	// pod template in machine-config-operator) so we never block pod
+	// shutdown.
 	resignFightDuration = 30 * time.Second
 	// resignPollInterval is the poll/retry cadence for both phases.
 	resignPollInterval = time.Second
+	// resignQuietPolls is how many consecutive polls must find no VIP
+	// before the force-removal phase declares the VIPs gone for good.
+	resignQuietPolls = 3
 )
 
 // Stubbed in unit tests.
@@ -38,20 +44,30 @@ var (
 	removeVIPFn        = removeVIP
 )
 
-// isHostShuttingDown reports whether the host (not just this pod) is being
-// shut down or rebooted. The keepalived-monitor container mounts the host
-// filesystem at /host and runs with CAP_SYS_CHROOT, so we can ask the host's
-// systemd directly. Note systemctl is-system-running exits non-zero for every
-// state except "running", so the output must be inspected instead of the
-// error.
-func isHostShuttingDown() bool {
-	out, err := exec.Command("chroot", "/host", "systemctl", "is-system-running").Output()
+// hostStateIsStopping interprets `systemctl is-system-running` results.
+// systemctl exits non-zero for every state except "running", so the output
+// must be inspected instead of the error. An empty output means the state
+// could not be determined; be conservative and report "not stopping" so that
+// a mere pod restart can never flap the VIPs of a healthy node.
+func hostStateIsStopping(out []byte, err error) bool {
 	state := strings.TrimSpace(string(out))
-	if state == "" && err != nil {
-		log.WithError(err).Info("handleShutdownResign: could not determine host state")
+	if state == "" {
+		if err != nil {
+			log.WithError(err).Warn("handleShutdownResign: could not determine host state, assuming the host is not shutting down")
+		}
 		return false
 	}
 	return state == "stopping"
+}
+
+// isHostShuttingDown reports whether the host (not just this pod) is being
+// shut down or rebooted. The keepalived-monitor container mounts the host
+// filesystem at /host and runs with CAP_SYS_CHROOT, so we can ask the host's
+// systemd directly. The chroot binary path is pinned so a PATH change cannot
+// silently disable the check.
+func isHostShuttingDown() bool {
+	out, err := exec.Command("/usr/sbin/chroot", "/host", "systemctl", "is-system-running").Output()
+	return hostStateIsStopping(out, err)
 }
 
 // listConfiguredVIPs returns the subset of vips currently configured on any
@@ -92,35 +108,44 @@ func removeVIP(link netlink.Link, addr netlink.Addr) error {
 	return netlink.AddrDel(link, &addr)
 }
 
-func anyVIPConfigured(vips []net.IP) bool {
+// anyVIPConfigured reports whether any of the vips is configured locally.
+// Errors are propagated so callers can decide how to fail: toward removal
+// during shutdown, never toward silently keeping a VIP.
+func anyVIPConfigured(vips []net.IP) (bool, error) {
 	configured, err := listVIPsFn(vips)
 	if err != nil {
-		log.WithError(err).Error("handleShutdownResign: failed to list addresses")
-		return false
+		return false, err
 	}
-	return len(configured) > 0
+	return len(configured) > 0, nil
 }
 
-func forceRemoveVIPs(vips []net.IP) bool {
+// removeConfiguredVIPs removes all locally configured vips. It returns how
+// many addresses were found and how many failed to be removed. An address
+// that disappeared between listing and removal (keepalived's own clean
+// shutdown racing with us) counts as removed.
+func removeConfiguredVIPs(vips []net.IP) (found, failed int, err error) {
 	configured, err := listVIPsFn(vips)
 	if err != nil {
-		log.WithError(err).Error("handleShutdownResign: failed to list addresses")
-		return false
+		return 0, 0, err
 	}
-	removedAll := true
 	for link, addrs := range configured {
 		for _, addr := range addrs {
+			found++
 			log.WithFields(logrus.Fields{
 				"address": addr.IPNet.String(),
 				"link":    link.Attrs().Name,
 			}).Info("handleShutdownResign: force-removing VIP")
 			if err := removeVIPFn(link, addr); err != nil {
+				if errors.Is(err, unix.EADDRNOTAVAIL) || errors.Is(err, unix.ENOENT) {
+					// Already gone: someone else (keepalived) removed it first.
+					continue
+				}
 				log.WithError(err).Error("handleShutdownResign: failed to remove VIP")
-				removedAll = false
+				failed++
 			}
 		}
 	}
-	return removedAll && len(configured) > 0
+	return found, failed, nil
 }
 
 // handleShutdownResign makes sure no VIP stays configured on this node while
@@ -128,13 +153,13 @@ func forceRemoveVIPs(vips []net.IP) bool {
 // scopes in parallel and keepalived may be killed before it can send its VRRP
 // priority-0 resign advertisement and remove the VIPs. The stale VIP then
 // keeps attracting client connections which land directly on the local
-// kube-apiserver - still serving its graceful drain with readyz=false - for
-// up to ~70 seconds (OCPBUGS-109633).
+// kube-apiserver - still serving its graceful drain (~70s, the apiserver
+// shutdown-delay window) with readyz=false (OCPBUGS-109633).
 //
-// Called when dynkeepalived receives SIGTERM/SIGINT. It only acts when the
-// host itself is shutting down: an ordinary pod restart (MachineConfig
-// rollout, liveness restart, upgrade) must not touch the VIPs of a healthy
-// node.
+// Called when dynkeepalived exits, normally on SIGTERM/SIGINT. It only acts
+// when the host itself is shutting down: an ordinary pod restart
+// (MachineConfig rollout, liveness restart, upgrade) must not touch the VIPs
+// of a healthy node.
 func handleShutdownResign(conn io.Writer, vips []net.IP) {
 	if len(vips) == 0 {
 		return
@@ -143,7 +168,11 @@ func handleShutdownResign(conn io.Writer, vips []net.IP) {
 		log.Info("handleShutdownResign: host is not shutting down, leaving VIPs alone")
 		return
 	}
-	if !anyVIPConfigured(vips) {
+	if present, err := anyVIPConfigured(vips); err != nil {
+		// Unknown state during a confirmed host shutdown: fail toward
+		// resigning, never toward keeping a possibly stale VIP.
+		log.WithError(err).Warn("handleShutdownResign: failed to list addresses, proceeding with resign anyway")
+	} else if !present {
 		log.Info("handleShutdownResign: no VIP configured on this node, nothing to do")
 		return
 	}
@@ -157,7 +186,7 @@ func handleShutdownResign(conn io.Writer, vips []net.IP) {
 	} else {
 		log.Info("handleShutdownResign: requested keepalived stop, waiting for clean VIP resign")
 		for deadline := time.Now().Add(resignStopWait); time.Now().Before(deadline); {
-			if !anyVIPConfigured(vips) {
+			if present, err := anyVIPConfigured(vips); err == nil && !present {
 				log.Info("handleShutdownResign: all VIPs resigned cleanly")
 				return
 			}
@@ -168,19 +197,31 @@ func handleShutdownResign(conn io.Writer, vips []net.IP) {
 	// Last resort: remove the VIPs directly. The peers take over via the
 	// VRRP master-down timeout (~3-4s). A still-running keepalived in
 	// MASTER state re-adds monitored addresses, so keep removing until the
-	// VIPs stay gone or the fight window closes.
+	// VIPs stay gone for several consecutive polls or the fight window
+	// closes. Errors leave the state unknown and only ever prolong the
+	// fight; they are never mistaken for success.
 	quietPolls := 0
 	for deadline := time.Now().Add(resignFightDuration); time.Now().Before(deadline); {
-		if forceRemoveVIPs(vips) {
+		found, failed, err := removeConfiguredVIPs(vips)
+		switch {
+		case err != nil:
+			log.WithError(err).Warn("handleShutdownResign: failed to list addresses, retrying")
 			quietPolls = 0
-		} else {
+		case found == 0:
 			quietPolls++
-			if quietPolls >= 3 {
+			if quietPolls >= resignQuietPolls {
 				log.Info("handleShutdownResign: VIPs stayed removed")
 				return
+			}
+		default:
+			quietPolls = 0
+			if failed > 0 {
+				log.WithFields(logrus.Fields{
+					"failed": failed,
+				}).Warn("handleShutdownResign: some VIPs could not be removed, retrying")
 			}
 		}
 		time.Sleep(resignPollInterval)
 	}
-	log.Warn("handleShutdownResign: fight window elapsed, VIPs may still be re-added by keepalived")
+	log.Warn("handleShutdownResign: fight window elapsed, VIPs may still be configured")
 }

--- a/pkg/monitor/shutdownresign_linux.go
+++ b/pkg/monitor/shutdownresign_linux.go
@@ -3,6 +3,7 @@
 package monitor
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -35,6 +36,14 @@ var (
 	// resignQuietPolls is how many consecutive polls must find no VIP
 	// before the force-removal phase declares the VIPs gone for good.
 	resignQuietPolls = 3
+	// hostStateCheckTimeout bounds the systemctl host-state query. If the
+	// host's systemd/dbus is wedged the query could otherwise hang forever,
+	// stalling the entire deferred resign. On timeout the state is unknown
+	// and we conservatively skip the resign; keepalived's own SIGTERM
+	// handling and the MCO shutdown unit remain as backstops. Total worst
+	// case stays bounded: 5s + resignStopWait + resignFightDuration = 45s,
+	// below the pod's 65s deletionGracePeriodSeconds.
+	hostStateCheckTimeout = 5 * time.Second
 )
 
 // Stubbed in unit tests.
@@ -64,9 +73,21 @@ func hostStateIsStopping(out []byte, err error) bool {
 // shut down or rebooted. The keepalived-monitor container mounts the host
 // filesystem at /host and runs with CAP_SYS_CHROOT, so we can ask the host's
 // systemd directly. The chroot binary path is pinned so a PATH change cannot
-// silently disable the check.
+// silently disable the check, and the query is bounded by
+// hostStateCheckTimeout so a wedged systemd/dbus cannot stall the resign.
 func isHostShuttingDown() bool {
-	out, err := exec.Command("/usr/sbin/chroot", "/host", "systemctl", "is-system-running").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), hostStateCheckTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/sbin/chroot", "/host", "systemctl", "is-system-running")
+	// Even after the context kills systemctl, Output() would keep waiting
+	// for the stdout pipe if a grandchild inherited it; WaitDelay bounds
+	// that wait too.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
+	if ctx.Err() != nil {
+		log.Warn("handleShutdownResign: host state query timed out, assuming the host is not shutting down")
+		return false
+	}
 	return hostStateIsStopping(out, err)
 }
 

--- a/pkg/monitor/shutdownresign_linux.go
+++ b/pkg/monitor/shutdownresign_linux.go
@@ -1,0 +1,186 @@
+//go:build linux
+
+package monitor
+
+import (
+	"io"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// Vars rather than consts so unit tests can shrink the windows.
+var (
+	// resignStopWait is how long we wait for keepalived to perform a clean
+	// shutdown (VRRP priority-0 advertisement + VIP removal) after sending
+	// "stop" over the control socket, before force-removing the VIPs.
+	resignStopWait = 10 * time.Second
+	// resignFightDuration bounds the force-removal phase. While keepalived
+	// is still alive in MASTER state it monitors its VIPs via netlink and
+	// re-adds any address deleted out from under it, so removal is retried
+	// until keepalived is gone or the node has finished shutting down the
+	// containers. This must stay below the pod termination grace period
+	// (65s) so we never block pod shutdown.
+	resignFightDuration = 30 * time.Second
+	// resignPollInterval is the poll/retry cadence for both phases.
+	resignPollInterval = time.Second
+)
+
+// Stubbed in unit tests.
+var (
+	hostShuttingDownFn = isHostShuttingDown
+	listVIPsFn         = listConfiguredVIPs
+	removeVIPFn        = removeVIP
+)
+
+// isHostShuttingDown reports whether the host (not just this pod) is being
+// shut down or rebooted. The keepalived-monitor container mounts the host
+// filesystem at /host and runs with CAP_SYS_CHROOT, so we can ask the host's
+// systemd directly. Note systemctl is-system-running exits non-zero for every
+// state except "running", so the output must be inspected instead of the
+// error.
+func isHostShuttingDown() bool {
+	out, err := exec.Command("chroot", "/host", "systemctl", "is-system-running").Output()
+	state := strings.TrimSpace(string(out))
+	if state == "" && err != nil {
+		log.WithError(err).Info("handleShutdownResign: could not determine host state")
+		return false
+	}
+	return state == "stopping"
+}
+
+// listConfiguredVIPs returns the subset of vips currently configured on any
+// interface, together with the netlink handles needed to remove them.
+// Comparison is done on the parsed address, so textual differences (IPv6
+// compression, case) do not matter.
+func listConfiguredVIPs(vips []net.IP) (map[netlink.Link][]netlink.Addr, error) {
+	nlHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
+	if err != nil {
+		return nil, err
+	}
+	defer nlHandle.Delete()
+
+	links, err := nlHandle.LinkList()
+	if err != nil {
+		return nil, err
+	}
+
+	configured := make(map[netlink.Link][]netlink.Addr)
+	for _, link := range links {
+		addresses, err := nlHandle.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return nil, err
+		}
+		for _, address := range addresses {
+			for _, vip := range vips {
+				if address.IP.Equal(vip) {
+					configured[link] = append(configured[link], address)
+					break
+				}
+			}
+		}
+	}
+	return configured, nil
+}
+
+func removeVIP(link netlink.Link, addr netlink.Addr) error {
+	return netlink.AddrDel(link, &addr)
+}
+
+func anyVIPConfigured(vips []net.IP) bool {
+	configured, err := listVIPsFn(vips)
+	if err != nil {
+		log.WithError(err).Error("handleShutdownResign: failed to list addresses")
+		return false
+	}
+	return len(configured) > 0
+}
+
+func forceRemoveVIPs(vips []net.IP) bool {
+	configured, err := listVIPsFn(vips)
+	if err != nil {
+		log.WithError(err).Error("handleShutdownResign: failed to list addresses")
+		return false
+	}
+	removedAll := true
+	for link, addrs := range configured {
+		for _, addr := range addrs {
+			log.WithFields(logrus.Fields{
+				"address": addr.IPNet.String(),
+				"link":    link.Attrs().Name,
+			}).Info("handleShutdownResign: force-removing VIP")
+			if err := removeVIPFn(link, addr); err != nil {
+				log.WithError(err).Error("handleShutdownResign: failed to remove VIP")
+				removedAll = false
+			}
+		}
+	}
+	return removedAll && len(configured) > 0
+}
+
+// handleShutdownResign makes sure no VIP stays configured on this node while
+// it shuts down. During "systemctl reboot" systemd tears down all container
+// scopes in parallel and keepalived may be killed before it can send its VRRP
+// priority-0 resign advertisement and remove the VIPs. The stale VIP then
+// keeps attracting client connections which land directly on the local
+// kube-apiserver - still serving its graceful drain with readyz=false - for
+// up to ~70 seconds (OCPBUGS-109633).
+//
+// Called when dynkeepalived receives SIGTERM/SIGINT. It only acts when the
+// host itself is shutting down: an ordinary pod restart (MachineConfig
+// rollout, liveness restart, upgrade) must not touch the VIPs of a healthy
+// node.
+func handleShutdownResign(conn io.Writer, vips []net.IP) {
+	if len(vips) == 0 {
+		return
+	}
+	if !hostShuttingDownFn() {
+		log.Info("handleShutdownResign: host is not shutting down, leaving VIPs alone")
+		return
+	}
+	if !anyVIPConfigured(vips) {
+		log.Info("handleShutdownResign: no VIP configured on this node, nothing to do")
+		return
+	}
+
+	// Ask the keepalived container to stop keepalived cleanly: on SIGTERM
+	// keepalived sends a priority-0 advertisement (instant failover on the
+	// peers) and removes the VIPs. Wrappers that do not implement "stop"
+	// simply ignore the message and we fall through to force-removal.
+	if _, err := conn.Write([]byte("stop\n")); err != nil {
+		log.WithError(err).Error("handleShutdownResign: failed to write stop to keepalived control socket")
+	} else {
+		log.Info("handleShutdownResign: requested keepalived stop, waiting for clean VIP resign")
+		for deadline := time.Now().Add(resignStopWait); time.Now().Before(deadline); {
+			if !anyVIPConfigured(vips) {
+				log.Info("handleShutdownResign: all VIPs resigned cleanly")
+				return
+			}
+			time.Sleep(resignPollInterval)
+		}
+	}
+
+	// Last resort: remove the VIPs directly. The peers take over via the
+	// VRRP master-down timeout (~3-4s). A still-running keepalived in
+	// MASTER state re-adds monitored addresses, so keep removing until the
+	// VIPs stay gone or the fight window closes.
+	quietPolls := 0
+	for deadline := time.Now().Add(resignFightDuration); time.Now().Before(deadline); {
+		if forceRemoveVIPs(vips) {
+			quietPolls = 0
+		} else {
+			quietPolls++
+			if quietPolls >= 3 {
+				log.Info("handleShutdownResign: VIPs stayed removed")
+				return
+			}
+		}
+		time.Sleep(resignPollInterval)
+	}
+	log.Warn("handleShutdownResign: fight window elapsed, VIPs may still be re-added by keepalived")
+}

--- a/pkg/monitor/shutdownresign_linux_test.go
+++ b/pkg/monitor/shutdownresign_linux_test.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package monitor
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+)
+
+type fakeVIPState struct {
+	// configured maps VIP string -> present
+	configured map[string]bool
+	// reAdd makes the fake re-add every removed VIP on the next list call,
+	// mimicking a still-running keepalived in MASTER state.
+	reAdd       bool
+	removeCalls int
+	listErr     error
+}
+
+func (f *fakeVIPState) list(vips []net.IP) (map[netlink.Link][]netlink.Addr, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	res := make(map[netlink.Link][]netlink.Addr)
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "ens192"}}
+	for _, vip := range vips {
+		if f.configured[vip.String()] {
+			res[link] = append(res[link], netlink.Addr{IPNet: netlink.NewIPNet(vip)})
+		}
+	}
+	return res, nil
+}
+
+func (f *fakeVIPState) remove(link netlink.Link, addr netlink.Addr) error {
+	f.removeCalls++
+	f.configured[addr.IP.String()] = f.reAdd
+	return nil
+}
+
+var _ = Describe("handleShutdownResign", func() {
+	var (
+		fake     *fakeVIPState
+		conn     *bytes.Buffer
+		stopping bool
+		vips     []net.IP
+
+		origStopWait time.Duration
+		origFight    time.Duration
+		origPoll     time.Duration
+
+		origHostShuttingDown func() bool
+		origList             func([]net.IP) (map[netlink.Link][]netlink.Addr, error)
+		origRemove           func(netlink.Link, netlink.Addr) error
+	)
+
+	BeforeEach(func() {
+		fake = &fakeVIPState{configured: map[string]bool{}}
+		conn = &bytes.Buffer{}
+		stopping = true
+		vips = []net.IP{net.ParseIP("192.0.2.5"), net.ParseIP("fd00::5")}
+
+		origStopWait, origFight, origPoll = resignStopWait, resignFightDuration, resignPollInterval
+		resignStopWait = 30 * time.Millisecond
+		resignFightDuration = 100 * time.Millisecond
+		resignPollInterval = 10 * time.Millisecond
+
+		origHostShuttingDown = hostShuttingDownFn
+		origList = listVIPsFn
+		origRemove = removeVIPFn
+		hostShuttingDownFn = func() bool { return stopping }
+		listVIPsFn = func(v []net.IP) (map[netlink.Link][]netlink.Addr, error) { return fake.list(v) }
+		removeVIPFn = func(l netlink.Link, a netlink.Addr) error { return fake.remove(l, a) }
+	})
+
+	AfterEach(func() {
+		resignStopWait, resignFightDuration, resignPollInterval = origStopWait, origFight, origPoll
+		hostShuttingDownFn = origHostShuttingDown
+		listVIPsFn = origList
+		removeVIPFn = origRemove
+	})
+
+	It("does nothing when the host is not shutting down", func() {
+		stopping = false
+		fake.configured["192.0.2.5"] = true
+		handleShutdownResign(conn, vips)
+		Expect(conn.String()).To(BeEmpty())
+		Expect(fake.removeCalls).To(BeZero())
+		Expect(fake.configured["192.0.2.5"]).To(BeTrue())
+	})
+
+	It("does nothing when no VIP is configured locally", func() {
+		handleShutdownResign(conn, vips)
+		Expect(conn.String()).To(BeEmpty())
+		Expect(fake.removeCalls).To(BeZero())
+	})
+
+	It("does nothing when the VIP list is empty", func() {
+		handleShutdownResign(conn, nil)
+		Expect(conn.String()).To(BeEmpty())
+	})
+
+	It("requests a clean keepalived stop and returns once the VIPs are gone", func() {
+		fake.configured["192.0.2.5"] = true
+		// Simulate keepalived resigning cleanly right after the stop
+		// message: the first poll already sees no VIPs.
+		listCalls := 0
+		listVIPsFn = func(v []net.IP) (map[netlink.Link][]netlink.Addr, error) {
+			listCalls++
+			if listCalls == 1 {
+				return fake.list(v)
+			}
+			return map[netlink.Link][]netlink.Addr{}, nil
+		}
+		handleShutdownResign(conn, vips)
+		Expect(conn.String()).To(Equal("stop\n"))
+		Expect(fake.removeCalls).To(BeZero())
+	})
+
+	It("force-removes the VIPs when keepalived does not resign", func() {
+		fake.configured["192.0.2.5"] = true
+		fake.configured["fd00::5"] = true
+		handleShutdownResign(conn, vips)
+		Expect(conn.String()).To(Equal("stop\n"))
+		Expect(fake.removeCalls).To(Equal(2))
+		Expect(fake.configured["192.0.2.5"]).To(BeFalse())
+		Expect(fake.configured["fd00::5"]).To(BeFalse())
+	})
+
+	It("keeps removing while keepalived re-adds the VIP, then gives up at the fight window", func() {
+		fake.configured["192.0.2.5"] = true
+		fake.reAdd = true
+		handleShutdownResign(conn, vips)
+		// One removal per poll for the duration of the fight window.
+		Expect(fake.removeCalls).To(BeNumerically(">=", int(resignFightDuration/resignPollInterval)-1))
+	})
+
+	It("falls through to force-removal when listing fails during the wait", func() {
+		fake.configured["192.0.2.5"] = true
+		fake.listErr = errors.New("netlink down")
+		handleShutdownResign(conn, vips)
+		// anyVIPConfigured returns false on error, so the initial check
+		// already bails out before writing to the socket.
+		Expect(conn.String()).To(BeEmpty())
+		Expect(fake.removeCalls).To(BeZero())
+	})
+})

--- a/pkg/monitor/shutdownresign_linux_test.go
+++ b/pkg/monitor/shutdownresign_linux_test.go
@@ -11,21 +11,32 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 type fakeVIPState struct {
 	// configured maps VIP string -> present
 	configured map[string]bool
-	// reAdd makes the fake re-add every removed VIP on the next list call,
-	// mimicking a still-running keepalived in MASTER state.
-	reAdd       bool
-	removeCalls int
-	listErr     error
+	// reAdd makes remove() leave the VIP configured, mimicking a
+	// still-running keepalived in MASTER state that re-adds monitored
+	// addresses as soon as they are deleted.
+	reAdd bool
+	// resignAfterLists empties configured after this many list calls,
+	// mimicking keepalived resigning cleanly after the stop request.
+	resignAfterLists int
+	removeCalls      int
+	listCalls        int
+	listErr          error
+	removeErr        error
 }
 
 func (f *fakeVIPState) list(vips []net.IP) (map[netlink.Link][]netlink.Addr, error) {
+	f.listCalls++
 	if f.listErr != nil {
 		return nil, f.listErr
+	}
+	if f.resignAfterLists > 0 && f.listCalls > f.resignAfterLists {
+		f.configured = map[string]bool{}
 	}
 	res := make(map[netlink.Link][]netlink.Addr)
 	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "ens192"}}
@@ -39,9 +50,39 @@ func (f *fakeVIPState) list(vips []net.IP) (map[netlink.Link][]netlink.Addr, err
 
 func (f *fakeVIPState) remove(link netlink.Link, addr netlink.Addr) error {
 	f.removeCalls++
+	if f.removeErr != nil {
+		return f.removeErr
+	}
 	f.configured[addr.IP.String()] = f.reAdd
 	return nil
 }
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }
+
+var _ = Describe("hostStateIsStopping", func() {
+	exitErr := errors.New("exit status 1")
+
+	It("reports stopping for 'stopping' output even with a non-zero exit", func() {
+		// systemctl is-system-running exits non-zero for every state
+		// except "running".
+		Expect(hostStateIsStopping([]byte("stopping\n"), exitErr)).To(BeTrue())
+	})
+
+	It("reports not stopping for 'running'", func() {
+		Expect(hostStateIsStopping([]byte("running\n"), nil)).To(BeFalse())
+	})
+
+	It("reports not stopping for 'degraded'", func() {
+		Expect(hostStateIsStopping([]byte("degraded\n"), exitErr)).To(BeFalse())
+	})
+
+	It("reports not stopping when the state cannot be determined", func() {
+		Expect(hostStateIsStopping(nil, exitErr)).To(BeFalse())
+		Expect(hostStateIsStopping([]byte(""), nil)).To(BeFalse())
+	})
+})
 
 var _ = Describe("handleShutdownResign", func() {
 	var (
@@ -107,32 +148,28 @@ var _ = Describe("handleShutdownResign", func() {
 
 	It("requests a clean keepalived stop and returns once the VIPs are gone", func() {
 		fake.configured["192.0.2.5"] = true
-		// Simulate keepalived resigning cleanly right after the stop
-		// message: the first poll already sees no VIPs.
-		listCalls := 0
-		listVIPsFn = func(v []net.IP) (map[netlink.Link][]netlink.Addr, error) {
-			listCalls++
-			if listCalls == 1 {
-				return fake.list(v)
-			}
-			return map[netlink.Link][]netlink.Addr{}, nil
-		}
+		// keepalived resigns cleanly right after the stop message.
+		fake.resignAfterLists = 1
 		handleShutdownResign(conn, vips)
 		Expect(conn.String()).To(Equal("stop\n"))
 		Expect(fake.removeCalls).To(BeZero())
 	})
 
-	It("force-removes the VIPs when keepalived does not resign", func() {
+	It("force-removes the VIPs and exits early once they stay gone", func() {
 		fake.configured["192.0.2.5"] = true
 		fake.configured["fd00::5"] = true
+		start := time.Now()
 		handleShutdownResign(conn, vips)
 		Expect(conn.String()).To(Equal("stop\n"))
 		Expect(fake.removeCalls).To(Equal(2))
 		Expect(fake.configured["192.0.2.5"]).To(BeFalse())
 		Expect(fake.configured["fd00::5"]).To(BeFalse())
+		// The quiet-poll early exit must fire well before the full
+		// stop-wait + fight window elapses.
+		Expect(time.Since(start)).To(BeNumerically("<", resignStopWait+resignFightDuration))
 	})
 
-	It("keeps removing while keepalived re-adds the VIP, then gives up at the fight window", func() {
+	It("keeps removing while keepalived re-adds the VIP and never claims success", func() {
 		fake.configured["192.0.2.5"] = true
 		fake.reAdd = true
 		handleShutdownResign(conn, vips)
@@ -140,13 +177,49 @@ var _ = Describe("handleShutdownResign", func() {
 		Expect(fake.removeCalls).To(BeNumerically(">=", int(resignFightDuration/resignPollInterval)-1))
 	})
 
-	It("falls through to force-removal when listing fails during the wait", func() {
+	It("does not declare success while removal keeps failing", func() {
 		fake.configured["192.0.2.5"] = true
+		fake.removeErr = errors.New("operation not permitted")
+		handleShutdownResign(conn, vips)
+		// The VIP stays configured, so every fight poll must retry until
+		// the window elapses instead of exiting via the quiet-poll path.
+		Expect(fake.removeCalls).To(BeNumerically(">=", int(resignFightDuration/resignPollInterval)-1))
+		Expect(fake.configured["192.0.2.5"]).To(BeTrue())
+	})
+
+	It("treats an address already removed by keepalived as removed", func() {
+		fake.configured["192.0.2.5"] = true
+		firstRemove := true
+		removeVIPFn = func(l netlink.Link, a netlink.Addr) error {
+			fake.removeCalls++
+			if firstRemove {
+				firstRemove = false
+				// keepalived deleted it between our list and remove.
+				fake.configured[a.IP.String()] = false
+				return unix.EADDRNOTAVAIL
+			}
+			return nil
+		}
+		start := time.Now()
+		handleShutdownResign(conn, vips)
+		Expect(fake.removeCalls).To(Equal(1))
+		Expect(time.Since(start)).To(BeNumerically("<", resignStopWait+resignFightDuration))
+	})
+
+	It("proceeds with the resign when the initial listing fails", func() {
 		fake.listErr = errors.New("netlink down")
 		handleShutdownResign(conn, vips)
-		// anyVIPConfigured returns false on error, so the initial check
-		// already bails out before writing to the socket.
-		Expect(conn.String()).To(BeEmpty())
-		Expect(fake.removeCalls).To(BeZero())
+		// Unknown address state during a confirmed host shutdown must
+		// fail toward resigning: the stop request is still sent and the
+		// force-removal phase still polls until the window closes.
+		Expect(conn.String()).To(Equal("stop\n"))
+	})
+
+	It("falls back to force-removal when the stop request cannot be sent", func() {
+		fake.configured["192.0.2.5"] = true
+		listCallsBefore := 0
+		handleShutdownResign(failingWriter{}, vips)
+		Expect(fake.removeCalls).To(BeNumerically(">", listCallsBefore))
+		Expect(fake.configured["192.0.2.5"]).To(BeFalse())
 	})
 })

--- a/pkg/monitor/shutdownresign_nonlinux.go
+++ b/pkg/monitor/shutdownresign_nonlinux.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package monitor
+
+import (
+	"io"
+	"net"
+)
+
+// handleShutdownResign is only supported on Linux; on other platforms it is
+// a no-op so the package still compiles.
+func handleShutdownResign(conn io.Writer, vips []net.IP) {
+}


### PR DESCRIPTION
Durable fix for [OCPBUGS-109633](https://issues.redhat.com/browse/OCPBUGS-109633), follow-up 6 of [openshift/machine-config-operator#6402](https://github.com/openshift/machine-config-operator/pull/6402): move the shutdown VIP-resign logic to where VRRP state and VIP knowledge live.

## Problem

During `systemctl reboot` systemd tears down all container scopes in parallel. Whether keepalived manages to send its VRRP priority-0 resign advert and remove the VIPs before being killed is a race. When it loses, the stale VIP keeps attracting new client connections which land **directly** on the local kube-apiserver — still serving its ~70s graceful drain with `readyz=false` — because the haproxy `VIP:6443→:9445` nftables redirect is torn down at the same time. Caught by Component Readiness as a regression of `[Monitor:audit-log-analyzer] API LBs follow /readyz ...` on `periodic-ci-openshift-release-main-ci-5.0-e2e-vsphere-ovn-upgrade` (regression 46508, triage 722): peers took MASTER via the 3–4s master-down timeout with no priority-0 advert received, while flagged requests kept terminating on the rebooting node's draining apiserver for ~70s.

## What this PR does

On SIGTERM, `dynkeepalived` (keepalived-monitor) now runs a shutdown resign sequence:

1. **Guard**: only acts when the *host* is shutting down — checked via the host's systemd (`chroot /host systemctl is-system-running` == `stopping`; the container already mounts `/host` and has `CAP_SYS_CHROOT`). An ordinary pod restart (MachineConfig rollout, liveness restart, upgrade) never touches the VIPs of a healthy node. Note `is-system-running` exits non-zero for every state except `running`, so the output is inspected, not the exit code.
2. **No-op** if none of the API/ingress VIPs is configured locally (netlink address comparison, so IPv6 spelling differences don't matter).
3. **Clean path**: sends `stop\n` over the existing keepalived control socket (same mechanism the bootstrap flow already uses), so keepalived sends the priority-0 advert (instant peer failover) and removes the VIPs itself; waits up to 10s.
4. **Fallback**: force-removes the VIPs via netlink. Because a still-running keepalived in MASTER state re-adds monitored addresses, removal is retried until the VIPs stay gone, bounded to 30s (< the pod's 65s termination grace).

## Notes for reviewers

- The MCO keepalived wrapper currently implements only `reload`; the bootstrap wrapper already implements `stop`. Until MCO adds `stop` support (trivial follow-up in the wrapper's `msg_handler`), masters/workers take the netlink force-removal path, which still guarantees no stale VIP survives into the drain window (peers fail over via the ~3–4s master-down timeout).
- Complements (and can eventually replace) the systemd-unit approach in openshift/machine-config-operator#6402; the two are independent and safe to run together — both paths are idempotent no-ops when the VIP is already gone.
- Timing windows are package `var`s so the unit tests can shrink them; tests cover: healthy-node restart (no-op), no local VIP (no-op), clean resign after `stop`, force-removal, keepalived fighting re-adds, and netlink listing failure.

## Testing

- `go test ./...` — new ginkgo specs in `pkg/monitor/shutdownresign_linux_test.go` pass along with the existing suite.
- `go build ./...` on linux and a `GOOS=darwin` cross-compile (non-linux stub).
- Suggested cluster verification: on a VIP-holding master, loop `systemctl reboot` ~20x; confirm the VIP disappears from the rebooting node before the apiserver drain window, peers log either `Backup received priority 0 advertisement` or take over within ~4s, and that a plain `oc delete pod`/static-pod restart of keepalived-monitor does *not* move the VIP.

---
This PR was generated using AI. Please verify before acting on it.
Assisted-By: Claude Fable 5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host shutdown handling by cleanly stopping keepalived and removing configured virtual IPs.
  * Added a fallback to force-remove virtual IPs that remain assigned during shutdown.
  * Prevented cleanup from running during pod-only restarts.
  * Added compatible behavior for non-Linux platforms without shutdown cleanup.

* **Documentation**
  * Documented shutdown behavior and virtual IP cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->