### PR TITLE
OCPBUGS-98258: Cloud Platforms: Filter out node's own IP from Upstreams

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -987,20 +987,59 @@ func updateNodewithCloudInfo(apiLBIP, apiIntLBIP, ingressIP net.IP, resolvConfPa
 	if err != nil {
 		return node, err
 	}
-	// Extract only useful upstream addresses
-	node.DNSUpstreams = make([]string, 0)
-	for _, upstream := range resolvConfUpstreams {
-		if upstream != "127.0.0.1" && upstream != "::1" {
-			log.Infof("Adding %s as DNS Upstream", upstream)
-			node.DNSUpstreams = append(node.DNSUpstreams, upstream)
-		}
+	// On cloud platforms with UserProvisionedDNS, the update-dns-server service
+	// injects the node's own IP into NetworkManager's DNS configuration so that
+	// the node resolves api/api-int/*.apps via the local CoreDNS static pod.
+	// As a result the node's own IP appears in every resolv.conf NetworkManager
+	// generates (both /etc/resolv.conf and /var/run/NetworkManager/resolv.conf).
+	// A hostNetwork CoreDNS must never forward to itself, so exclude the node's
+	// own addresses from the upstreams to avoid a resolution loop.
+	nodeAddrs, err := utils.AddressesDefault(false, utils.ValidNodeAddress)
+	if err != nil {
+		// Don't fail rendering over an inability to enumerate local addresses;
+		// fall back to filtering loopback only.
+		log.Warningf("Failed to determine node addresses, DNS upstreams will only be filtered for loopback: %s", err)
+		nodeAddrs = nil
 	}
+	node.DNSUpstreams = filterDNSUpstreams(resolvConfUpstreams, nodeAddrs)
 	// Having no DNS Upstream servers is invalid. Return error so init
 	// container can retry.
 	if len(node.DNSUpstreams) < 1 {
 		return node, errors.New("No upstream DNS servers found")
 	}
 	return node, nil
+}
+
+// filterDNSUpstreams returns the resolv.conf nameservers that are valid CoreDNS
+// forward upstreams, dropping unparseable entries, loopback addresses, and any
+// of the node's own addresses. A hostNetwork CoreDNS listening on the node IP
+// would loop if it forwarded queries back to that same address, so those
+// entries are removed.
+func filterDNSUpstreams(resolvConfUpstreams []string, nodeAddrs []net.IP) []string {
+	upstreams := make([]string, 0)
+	for _, upstream := range resolvConfUpstreams {
+		upstreamIP := net.ParseIP(upstream)
+		if upstreamIP == nil {
+			continue
+		}
+		if upstreamIP.IsLoopback() {
+			continue
+		}
+		isNodeAddr := false
+		for _, addr := range nodeAddrs {
+			if addr.Equal(upstreamIP) {
+				isNodeAddr = true
+				break
+			}
+		}
+		if isNodeAddr {
+			log.Infof("Skipping node-local address %s as DNS upstream", upstream)
+			continue
+		}
+		log.Infof("Adding %s as DNS Upstream", upstream)
+		upstreams = append(upstreams, upstream)
+	}
+	return upstreams
 }
 
 func PopulateCloudLBIPAddresses(clusterLBConfig ClusterLBConfig, node Node) (updatedNode Node, err error) {

--- a/pkg/config/node_test.go
+++ b/pkg/config/node_test.go
@@ -504,6 +504,46 @@ var _ = Describe("isOnPremPlatform", func() {
 	})
 })
 
+var _ = Describe("filterDNSUpstreams", func() {
+	nodeAddrs := []net.IP{net.ParseIP("10.0.0.5"), net.ParseIP("fd00::5")}
+
+	It("keeps real upstreams unchanged", func() {
+		upstreams := filterDNSUpstreams([]string{"169.254.169.254", "8.8.8.8"}, nodeAddrs)
+		Expect(upstreams).To(Equal([]string{"169.254.169.254", "8.8.8.8"}))
+	})
+
+	It("drops the node's own IPv4 and IPv6 addresses", func() {
+		upstreams := filterDNSUpstreams([]string{"10.0.0.5", "168.63.129.16", "fd00::5"}, nodeAddrs)
+		Expect(upstreams).To(Equal([]string{"168.63.129.16"}))
+	})
+
+	It("drops IPv4 and IPv6 loopback addresses", func() {
+		upstreams := filterDNSUpstreams([]string{"127.0.0.1", "127.0.0.53", "::1", "8.8.8.8"}, nodeAddrs)
+		Expect(upstreams).To(Equal([]string{"8.8.8.8"}))
+	})
+
+	It("drops unparseable entries", func() {
+		upstreams := filterDNSUpstreams([]string{"not-an-ip", "8.8.8.8"}, nodeAddrs)
+		Expect(upstreams).To(Equal([]string{"8.8.8.8"}))
+	})
+
+	It("matches node addresses regardless of textual form", func() {
+		upstreams := filterDNSUpstreams([]string{"fd00:0:0:0:0:0:0:5", "8.8.8.8"}, nodeAddrs)
+		Expect(upstreams).To(Equal([]string{"8.8.8.8"}))
+	})
+
+	It("returns an empty (non-nil) slice when everything is filtered", func() {
+		upstreams := filterDNSUpstreams([]string{"10.0.0.5", "127.0.0.1"}, nodeAddrs)
+		Expect(upstreams).NotTo(BeNil())
+		Expect(upstreams).To(BeEmpty())
+	})
+
+	It("filters loopback only when node addresses are unavailable", func() {
+		upstreams := filterDNSUpstreams([]string{"10.0.0.5", "127.0.0.1", "8.8.8.8"}, nil)
+		Expect(upstreams).To(Equal([]string{"10.0.0.5", "8.8.8.8"}))
+	})
+})
+
 func Test(t *testing.T) {
 	createTempResolvConf()
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
updateNodewithCloudInfo (the cloud/UserProvisionedDNS path) built CoreDNS's forward . upstreams from resolv.conf while filtering only loopback addresses. This caused the upstreams to also include the node's own IP address. This fix filters out a node's own IP from being included in the list of upstreams on cloud platforms AWS, Azure and GCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS upstream filtering to exclude invalid, loopback, and node-local addresses.
  * Prevented CoreDNS forwarding loops caused by unsuitable upstream addresses.
  * DNS configuration rendering now continues when local address discovery fails.
  * Added support for consistent IPv6 address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->