### PR TITLE
OCPBUGS-117270: Fix DNS upstream limit check in getDNSUpstreams

### DIFF
--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -155,8 +155,8 @@ func getDNSUpstreams(resolvConfPath string) (upstreams []string, err error) {
 		case "nameserver":
 			// CoreDNS forward plugin takes up to 15 upstream servers
 			if len(fields) > 1 && len(upstreams) < 15 {
+				upstreams = append(upstreams, fields[1])
 			}
-			upstreams = append(upstreams, fields[1])
 		}
 	}
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
The bounds/limit check had an empty if body, so upstreams were appended unconditionally, bypassing the CoreDNS 15-upstream cap and the fields[1] bounds check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS configuration now ignores entries without an address.
  * Limits configured DNS upstreams to a maximum of 15 entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->