### PR TITLE
WIP: OPNET-679: Block external access to CoreDNS, driven by externalDNSAccessPolicy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,27 @@ corednsmonitor path_to_kubeconfig path_to_keepalived_cfg_template path_to_config
 - `--cloud-ingress-lb-ips`: IP Addresses of Cloud Ingress Load Balancers
 - `-p, --platform`: Cluster Platform
 
+**External DNS access blocking:**
+
+External access to CoreDNS (TCP/UDP port 53) can be blocked via nftables rules that
+allow only loopback-delivered (node-local) queries. This is driven by the
+`externalDNSAccessPolicy` field on the cluster `Infrastructure` resource
+(`status.platformStatus.baremetal.externalDNSAccessPolicy`), read live from the API
+each reconcile:
+- `Deny`: install the block rules.
+- `Allow`, omitted, or unreadable: do not block (fail-open).
+
+The rules require the container to have `CAP_NET_ADMIN`, and the container's identity
+needs `get` on `infrastructures.config.openshift.io` (both granted by the
+machine-config-operator).
+
 **Functionality:**
 - Monitors CoreDNS configuration for changes
 - Supports multiple API and Ingress VIPs
 - Handles cloud platform configurations
 - Automatically updates Corefile when interface changes are detected
+- Blocks external access to CoreDNS via nftables based on `externalDNSAccessPolicy`
+  (see External DNS access blocking)
 
 ---
 

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -90,7 +90,12 @@ type Node struct {
 	DNSUpstreams  []string
 	IngressConfig IngressConfig
 	EnableUnicast bool
-	Configs       *[]Node
+	// BlockExternalDNS gates the nftables rules that restrict CoreDNS to
+	// node-local access. It is currently populated from a placeholder env var
+	// (COREDNS_BLOCK_EXTERNAL_ACCESS) and will later be driven by a dedicated
+	// OpenShift API field.
+	BlockExternalDNS bool
+	Configs          *[]Node
 }
 
 type ClusterLBConfig struct {
@@ -707,6 +712,14 @@ func getNodeConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, api
 	node.EnableUnicast = false
 	if os.Getenv("ENABLE_UNICAST") == "yes" {
 		node.EnableUnicast = true
+	}
+
+	// Placeholder for the future OpenShift API field that controls whether
+	// external access to CoreDNS is blocked. When that field lands, only this
+	// population source changes; consumers keep reading node.BlockExternalDNS.
+	node.BlockExternalDNS = false
+	if os.Getenv("COREDNS_BLOCK_EXTERNAL_ACCESS") == "yes" {
+		node.BlockExternalDNS = true
 	}
 
 	resolvConfUpstreams, err := getDNSUpstreams(resolvConfPath)

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -17,6 +17,9 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -652,6 +655,51 @@ func GetConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVips
 	return nodes[0], nil
 }
 
+// infrastructureGVR identifies the cluster-scoped Infrastructure config resource.
+var infrastructureGVR = schema.GroupVersionResource{
+	Group:    "config.openshift.io",
+	Version:  "v1",
+	Resource: "infrastructures",
+}
+
+// externalDNSAccessDenied is the externalDNSAccessPolicy value that means
+// external DNS access is not permitted and must be blocked.
+const externalDNSAccessDenied = "Deny"
+
+// externalDNSBlockedFromInfra reports whether external CoreDNS access should be
+// blocked based on status.platformStatus.baremetal.externalDNSAccessPolicy of
+// the given Infrastructure object. Only an explicit "Deny" blocks; an omitted
+// field or any other value returns false.
+func externalDNSBlockedFromInfra(infra *unstructured.Unstructured) bool {
+	policy, found, err := unstructured.NestedString(infra.Object, "status", "platformStatus", "baremetal", "externalDNSAccessPolicy")
+	if err != nil || !found {
+		return false
+	}
+	return policy == externalDNSAccessDenied
+}
+
+// getExternalDNSBlocked fetches the cluster Infrastructure resource and reports
+// whether external CoreDNS access should be blocked. It fails open: any error
+// (client setup, API read) results in false so DNS is not accidentally blocked.
+func getExternalDNSBlocked(kubeconfigPath string) bool {
+	cfg, err := utils.GetClientConfig("", kubeconfigPath)
+	if err != nil {
+		log.WithError(err).Error("Failed to build client config to read externalDNSAccessPolicy; not blocking external DNS")
+		return false
+	}
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		log.WithError(err).Error("Failed to create dynamic client to read externalDNSAccessPolicy; not blocking external DNS")
+		return false
+	}
+	infra, err := dc.Resource(infrastructureGVR).Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		log.WithError(err).Error("Failed to get Infrastructure resource to read externalDNSAccessPolicy; not blocking external DNS")
+		return false
+	}
+	return externalDNSBlockedFromInfra(infra)
+}
+
 func getNodeConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, apiVip net.IP, ingressVip net.IP, apiPort, lbPort, statPort uint16, platformType string, controlPlaneTopology string) (node Node, err error) {
 	clusterName, clusterDomain, err := GetClusterNameAndDomain(kubeconfigPath, clusterConfigPath)
 	if err != nil {
@@ -714,13 +762,10 @@ func getNodeConfig(kubeconfigPath, clusterConfigPath, resolvConfPath string, api
 		node.EnableUnicast = true
 	}
 
-	// Placeholder for the future OpenShift API field that controls whether
-	// external access to CoreDNS is blocked. When that field lands, only this
-	// population source changes; consumers keep reading node.BlockExternalDNS.
-	node.BlockExternalDNS = false
-	if os.Getenv("COREDNS_BLOCK_EXTERNAL_ACCESS") == "yes" {
-		node.BlockExternalDNS = true
-	}
+	// Whether external access to CoreDNS is blocked is driven by the
+	// externalDNSAccessPolicy field on the cluster Infrastructure resource's
+	// platformStatus.baremetal. Consumers read node.BlockExternalDNS.
+	node.BlockExternalDNS = getExternalDNSBlocked(kubeconfigPath)
 
 	resolvConfUpstreams, err := getDNSUpstreams(resolvConfPath)
 	if err != nil {

--- a/pkg/config/node_test.go
+++ b/pkg/config/node_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/installer/pkg/types/none"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
 
@@ -541,6 +542,38 @@ var _ = Describe("filterDNSUpstreams", func() {
 	It("filters loopback only when node addresses are unavailable", func() {
 		upstreams := filterDNSUpstreams([]string{"10.0.0.5", "127.0.0.1", "8.8.8.8"}, nil)
 		Expect(upstreams).To(Equal([]string{"10.0.0.5", "8.8.8.8"}))
+	})
+})
+
+var _ = Describe("externalDNSBlockedFromInfra", func() {
+	infraWithPolicy := func(policy interface{}) *unstructured.Unstructured {
+		baremetal := map[string]interface{}{}
+		if policy != nil {
+			baremetal["externalDNSAccessPolicy"] = policy
+		}
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"platformStatus": map[string]interface{}{
+					"baremetal": baremetal,
+				},
+			},
+		}}
+	}
+
+	It("blocks when the policy is Deny", func() {
+		Expect(externalDNSBlockedFromInfra(infraWithPolicy("Deny"))).To(BeTrue())
+	})
+	It("does not block when the policy is Allow", func() {
+		Expect(externalDNSBlockedFromInfra(infraWithPolicy("Allow"))).To(BeFalse())
+	})
+	It("does not block when the policy is omitted", func() {
+		Expect(externalDNSBlockedFromInfra(infraWithPolicy(nil))).To(BeFalse())
+	})
+	It("does not block when platformStatus.baremetal is absent", func() {
+		infra := &unstructured.Unstructured{Object: map[string]interface{}{
+			"status": map[string]interface{}{"platformStatus": map[string]interface{}{}},
+		}}
+		Expect(externalDNSBlockedFromInfra(infra)).To(BeFalse())
 	})
 })
 

--- a/pkg/monitor/corednsmonitor.go
+++ b/pkg/monitor/corednsmonitor.go
@@ -18,6 +18,9 @@ import (
 
 const resolvConfFilepath string = "/var/run/NetworkManager/resolv.conf"
 
+// corednsDNSPort is the port CoreDNS serves DNS on (host network).
+const corednsDNSPort uint16 = 53
+
 func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath string, apiVips, ingressVips []net.IP, interval time.Duration, apiLBIPs, apiIntLBIPs, ingressLBIPs []net.IP, platformType string) error {
 	signals := make(chan os.Signal, 1)
 	done := make(chan bool, 1)
@@ -50,6 +53,11 @@ func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath strin
 	for {
 		select {
 		case <-done:
+			// Remove any block rules we own so a container removal does not
+			// leave orphaned nftables state behind.
+			if err := cleanCorednsFirewallRules(corednsDNSPort); err != nil {
+				log.WithError(err).Error("Failed to clean CoreDNS firewall rules on shutdown")
+			}
 			return nil
 		default:
 			curMD5, err := utils.GetFileMd5(resolvConfFilepath)
@@ -67,6 +75,22 @@ func CorednsWatch(kubeconfigPath, clusterConfigPath, templatePath, cfgPath strin
 			newConfig, err = config.PopulateCloudLBIPAddresses(clusterLBConfig, newConfig)
 			if err != nil {
 				return err
+			}
+
+			// Reconcile the nftables rules that block external access to
+			// CoreDNS. This is gated on a setting that will be driven by a
+			// future OpenShift API field (currently a placeholder env var).
+			// Failures are logged, not fatal: they must not stop Corefile
+			// rendering, and the coredns-monitor container needs NET_ADMIN
+			// (granted by machine-config-operator) before rules can be applied.
+			if newConfig.BlockExternalDNS {
+				if err := ensureCorednsFirewallRules(corednsDNSPort); err != nil {
+					log.WithError(err).Error("Failed to ensure CoreDNS firewall rules")
+				}
+			} else {
+				if err := cleanCorednsFirewallRules(corednsDNSPort); err != nil {
+					log.WithError(err).Error("Failed to clean CoreDNS firewall rules")
+				}
 			}
 
 			config.PopulateNodeAddresses(kubeconfigPath, &newConfig, nodeWatcher)

--- a/pkg/monitor/nftables_linux.go
+++ b/pkg/monitor/nftables_linux.go
@@ -19,6 +19,15 @@ const (
 	chainPrerouting = "ocp_prerouting"
 	chainOutput     = "ocp_output"
 	ruleComment     = "OCP_API_LB_REDIRECT"
+
+	// CoreDNS "block external access" firewall. A single inet-family table
+	// handles IPv4, IPv6 and dual-stack uniformly: the drop rule carries no IP
+	// address and matches only on iifname, l4proto and the transport dport, all
+	// of which are L3-agnostic.
+	dnsFilterTableName     = "ocp_dns_filter"
+	dnsInputChainName      = "ocp_dns_input"
+	corednsBlockCommentTCP = "OCP_COREDNS_BLOCK_EXTERNAL_TCP"
+	corednsBlockCommentUDP = "OCP_COREDNS_BLOCK_EXTERNAL_UDP"
 )
 
 // getFamily returns (v4, v6 or 0 [invalid ip - error])
@@ -33,22 +42,26 @@ func getFamily(ipStr string) (nftables.TableFamily, error) {
 	return nftables.TableFamilyIPv6, nil
 }
 
-func getOrCreateTable(conn *nftables.Conn, family nftables.TableFamily) (*nftables.Table, error) {
+func getOrCreateTableOfFamily(conn *nftables.Conn, family nftables.TableFamily, name string) (*nftables.Table, error) {
 	tables, err := conn.ListTablesOfFamily(family)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tables: %v", err)
 	}
 	for _, table := range tables {
-		if table.Name == tableName {
+		if table.Name == name {
 			return table, nil
 		}
 	}
 	table := &nftables.Table{
 		Family: family,
-		Name:   tableName,
+		Name:   name,
 	}
 	table = conn.AddTable(table)
 	return table, nil
+}
+
+func getOrCreateTable(conn *nftables.Conn, family nftables.TableFamily) (*nftables.Table, error) {
+	return getOrCreateTableOfFamily(conn, family, tableName)
 }
 
 func getOrCreateChain(conn *nftables.Conn, table *nftables.Table, name string, hook *nftables.ChainHook) (*nftables.Chain, error) {
@@ -110,17 +123,7 @@ func exprMatchDestIP(apiVip string, family nftables.TableFamily) ([]expr.Any, er
 }
 
 func exprMatchTCP() []expr.Any {
-	return []expr.Any{
-		&expr.Meta{
-			Key:      expr.MetaKeyL4PROTO,
-			Register: 1,
-		},
-		&expr.Cmp{
-			Op:       expr.CmpOpEq,
-			Register: 1,
-			Data:     []byte{unix.IPPROTO_TCP},
-		},
-	}
+	return exprMatchL4Proto(unix.IPPROTO_TCP)
 }
 
 func exprMatchDestPort(port uint16) []expr.Any {
@@ -465,4 +468,214 @@ func checkHAProxyFirewallRules(apiVip string, apiPort, lbPort uint16) (bool, err
 	}
 
 	return (preroutingRule != nil && outputRule != nil), nil
+}
+
+// getOrCreateFilterInputChain returns (creating if necessary) a base filter
+// chain hooked at input with the default-accept policy, used to host the CoreDNS
+// block rules.
+func getOrCreateFilterInputChain(conn *nftables.Conn, table *nftables.Table) (*nftables.Chain, error) {
+	chains, err := conn.ListChainsOfTableFamily(table.Family)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chains: %v", err)
+	}
+	for _, chain := range chains {
+		if chain.Table.Name == table.Name && chain.Name == dnsInputChainName {
+			return chain, nil
+		}
+	}
+	policy := nftables.ChainPolicyAccept
+	chain := &nftables.Chain{
+		Name:     dnsInputChainName,
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookInput,
+		Priority: nftables.ChainPriorityFilter,
+		Policy:   &policy,
+	}
+	chain = conn.AddChain(chain)
+	return chain, nil
+}
+
+func exprMatchIIFNotLoopback() []expr.Any {
+	return []expr.Any{
+		&expr.Meta{
+			Key:      expr.MetaKeyIIFNAME,
+			Register: 1,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpNeq,
+			Register: 1,
+			Data:     []byte("lo\x00"), // null-terminated interface name
+		},
+	}
+}
+
+func exprMatchL4Proto(proto byte) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{
+			Key:      expr.MetaKeyL4PROTO,
+			Register: 1,
+		},
+		&expr.Cmp{
+			Op:       expr.CmpOpEq,
+			Register: 1,
+			Data:     []byte{proto},
+		},
+	}
+}
+
+func exprDrop() []expr.Any {
+	return []expr.Any{
+		&expr.Verdict{
+			Kind: expr.VerdictDrop,
+		},
+	}
+}
+
+// buildCorednsDropRule builds a rule that drops traffic to the CoreDNS port for
+// the given L4 protocol unless it arrives on the loopback interface. Locally
+// originated queries (including those a node sends to its own IPs) are delivered
+// via "lo" and thus fall through to the chain's accept policy.
+func buildCorednsDropRule(table *nftables.Table, chain *nftables.Chain, proto byte, port uint16, comment string) *nftables.Rule {
+	var exprs []expr.Any
+
+	exprs = append(exprs, exprMatchIIFNotLoopback()...)
+	exprs = append(exprs, exprMatchL4Proto(proto)...)
+	exprs = append(exprs, exprMatchDestPort(port)...)
+	exprs = append(exprs, exprDrop()...)
+
+	rule := &nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: exprs,
+	}
+	rule.UserData = userdata.AppendString(nil, userdata.TypeComment, comment)
+
+	return rule
+}
+
+// ensureCorednsFirewallRules installs nftables rules that block external access
+// to the CoreDNS port (TCP and UDP), allowing only loopback-delivered traffic.
+// It is idempotent.
+func ensureCorednsFirewallRules(port uint16) error {
+	conn, err := nftables.New()
+	if err != nil {
+		return fmt.Errorf("failed to create nftables connection: %v", err)
+	}
+	defer conn.CloseLasting()
+
+	table, err := getOrCreateTableOfFamily(conn, nftables.TableFamilyINet, dnsFilterTableName)
+	if err != nil {
+		return err
+	}
+
+	chain, err := getOrCreateFilterInputChain(conn, table)
+	if err != nil {
+		return err
+	}
+
+	protos := []struct {
+		proto   byte
+		comment string
+	}{
+		{unix.IPPROTO_TCP, corednsBlockCommentTCP},
+		{unix.IPPROTO_UDP, corednsBlockCommentUDP},
+	}
+
+	for _, p := range protos {
+		existingRule, err := findRuleByComment(conn, chain, p.comment)
+		if err != nil {
+			return err
+		}
+		if existingRule == nil {
+			conn.InsertRule(buildCorednsDropRule(table, chain, p.proto, port, p.comment))
+			log.WithFields(logrus.Fields{
+				"chain":   dnsInputChainName,
+				"table":   table.Name,
+				"comment": p.comment,
+				"port":    port,
+			}).Info("Inserting nftables CoreDNS block rule")
+		}
+	}
+
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush nftables changes: %v", err)
+	}
+
+	return nil
+}
+
+// cleanCorednsFirewallRules removes the CoreDNS block rules if present. It is
+// idempotent and safe to call when the rules do not exist.
+func cleanCorednsFirewallRules(port uint16) error {
+	conn, err := nftables.New()
+	if err != nil {
+		return fmt.Errorf("failed to create nftables connection: %v", err)
+	}
+	defer conn.CloseLasting()
+
+	table, err := getOrCreateTableOfFamily(conn, nftables.TableFamilyINet, dnsFilterTableName)
+	if err != nil {
+		return err
+	}
+
+	chain, err := getOrCreateFilterInputChain(conn, table)
+	if err != nil {
+		return err
+	}
+
+	for _, comment := range []string{corednsBlockCommentTCP, corednsBlockCommentUDP} {
+		rule, err := findRuleByComment(conn, chain, comment)
+		if err != nil {
+			return err
+		}
+		if rule != nil {
+			log.WithFields(logrus.Fields{
+				"chain":   dnsInputChainName,
+				"table":   table.Name,
+				"comment": comment,
+			}).Info("Removing nftables CoreDNS block rule")
+			if err := conn.DelRule(rule); err != nil {
+				return fmt.Errorf("failed to delete CoreDNS block rule %s: %v", comment, err)
+			}
+		}
+	}
+
+	if err := conn.Flush(); err != nil {
+		return fmt.Errorf("failed to flush nftables changes: %v", err)
+	}
+
+	return nil
+}
+
+// checkCorednsFirewallRules reports whether both CoreDNS block rules (TCP and
+// UDP) exist.
+func checkCorednsFirewallRules(port uint16) (bool, error) {
+	conn, err := nftables.New()
+	if err != nil {
+		return false, fmt.Errorf("failed to create nftables connection: %v", err)
+	}
+	defer conn.CloseLasting()
+
+	table, err := getOrCreateTableOfFamily(conn, nftables.TableFamilyINet, dnsFilterTableName)
+	if err != nil {
+		return false, err
+	}
+
+	chain, err := getOrCreateFilterInputChain(conn, table)
+	if err != nil {
+		return false, err
+	}
+
+	tcpRule, err := findRuleByComment(conn, chain, corednsBlockCommentTCP)
+	if err != nil {
+		return false, err
+	}
+
+	udpRule, err := findRuleByComment(conn, chain, corednsBlockCommentUDP)
+	if err != nil {
+		return false, err
+	}
+
+	return (tcpRule != nil && udpRule != nil), nil
 }

--- a/pkg/monitor/nftables_nonlinux.go
+++ b/pkg/monitor/nftables_nonlinux.go
@@ -18,3 +18,18 @@ func cleanHAProxyFirewallRules(apiVip string, apiPort, lbPort uint16) error {
 func checkHAProxyFirewallRules(apiVip string, apiPort, lbPort uint16) (bool, error) {
 	return false, fmt.Errorf("nftables firewall rules are only supported on Linux")
 }
+
+// ensureCorednsFirewallRules returns an error on non-linux because it is not supported on non-Linux platforms
+func ensureCorednsFirewallRules(port uint16) error {
+	return fmt.Errorf("nftables firewall rules are only supported on Linux")
+}
+
+// cleanCorednsFirewallRules returns an error on non-linux because it is not supported on non-Linux platforms
+func cleanCorednsFirewallRules(port uint16) error {
+	return fmt.Errorf("nftables firewall rules are only supported on Linux")
+}
+
+// checkCorednsFirewallRules returns an error on non-linux because it is not supported on non-Linux platforms
+func checkCorednsFirewallRules(port uint16) (bool, error) {
+	return false, fmt.Errorf("nftables firewall rules are only supported on Linux")
+}

--- a/vendor/k8s.io/client-go/dynamic/interface.go
+++ b/vendor/k8s.io/client-go/dynamic/interface.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface
+}
+
+type ResourceInterface interface {
+	Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error)
+	ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error)
+}
+
+type NamespaceableResourceInterface interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}
+
+// APIPathResolverFunc knows how to convert a groupVersion to its API path. The Kind field is optional.
+// TODO find a better place to move this for existing callers
+type APIPathResolverFunc func(kind schema.GroupVersionKind) string
+
+// LegacyAPIPathResolverFunc can resolve paths properly with the legacy API.
+// TODO find a better place to move this for existing callers
+func LegacyAPIPathResolverFunc(kind schema.GroupVersionKind) string {
+	if len(kind.Group) == 0 {
+		return "/api"
+	}
+	return "/apis"
+}

--- a/vendor/k8s.io/client-go/dynamic/scheme.go
+++ b/vendor/k8s.io/client-go/dynamic/scheme.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+var watchScheme = runtime.NewScheme()
+var basicScheme = runtime.NewScheme()
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(watchScheme, versionV1)
+	metav1.AddToGroupVersion(basicScheme, versionV1)
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+// basicNegotiatedSerializer is used to handle discovery and error handling serialization
+type basicNegotiatedSerializer struct{}
+
+func (s basicNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return []runtime.SerializerInfo{
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			EncodesAsText:    true,
+			Serializer:       json.NewSerializer(json.DefaultMetaFactory, unstructuredCreater{basicScheme}, unstructuredTyper{basicScheme}, false),
+			PrettySerializer: json.NewSerializer(json.DefaultMetaFactory, unstructuredCreater{basicScheme}, unstructuredTyper{basicScheme}, true),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: true,
+				Serializer:    json.NewSerializer(json.DefaultMetaFactory, basicScheme, basicScheme, false),
+				Framer:        json.Framer,
+			},
+		},
+	}
+}
+
+func (s basicNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return runtime.WithVersionEncoder{
+		Version:     gv,
+		Encoder:     encoder,
+		ObjectTyper: unstructuredTyper{basicScheme},
+	}
+}
+
+func (s basicNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return decoder
+}
+
+type unstructuredCreater struct {
+	nested runtime.ObjectCreater
+}
+
+func (c unstructuredCreater) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	out, err := c.nested.New(kind)
+	if err == nil {
+		return out, nil
+	}
+	out = &unstructured.Unstructured{}
+	out.GetObjectKind().SetGroupVersionKind(kind)
+	return out, nil
+}
+
+type unstructuredTyper struct {
+	nested runtime.ObjectTyper
+}
+
+func (t unstructuredTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	kinds, unversioned, err := t.nested.ObjectKinds(obj)
+	if err == nil {
+		return kinds, unversioned, nil
+	}
+	if _, ok := obj.(runtime.Unstructured); ok && !obj.GetObjectKind().GroupVersionKind().Empty() {
+		return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+	}
+	return nil, false, err
+}
+
+func (t unstructuredTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}

--- a/vendor/k8s.io/client-go/dynamic/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/simple.go
@@ -1,0 +1,437 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+type DynamicClient struct {
+	client rest.Interface
+}
+
+var _ Interface = &DynamicClient{}
+
+// ConfigFor returns a copy of the provided config with the
+// appropriate dynamic client defaults set.
+func ConfigFor(inConfig *rest.Config) *rest.Config {
+	config := rest.CopyConfig(inConfig)
+	config.AcceptContentTypes = "application/json"
+	config.ContentType = "application/json"
+	config.NegotiatedSerializer = basicNegotiatedSerializer{} // this gets used for discovery and error handling types
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	return config
+}
+
+// New creates a new DynamicClient for the given RESTClient.
+func New(c rest.Interface) *DynamicClient {
+	return &DynamicClient{client: c}
+}
+
+// NewForConfigOrDie creates a new DynamicClient for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) *DynamicClient {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// NewForConfig creates a new dynamic client or returns an error.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
+func NewForConfig(inConfig *rest.Config) (*DynamicClient, error) {
+	config := ConfigFor(inConfig)
+
+	httpClient, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(config, httpClient)
+}
+
+// NewForConfigAndClient creates a new dynamic client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(inConfig *rest.Config, h *http.Client) (*DynamicClient, error) {
+	config := ConfigFor(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/if-you-see-this-search-for-the-break"
+
+	restClient, err := rest.RESTClientForConfigAndClient(config, h)
+	if err != nil {
+		return nil, err
+	}
+	return &DynamicClient{client: restClient}, nil
+}
+
+type dynamicResourceClient struct {
+	client    *DynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+func (c *DynamicClient) Resource(resource schema.GroupVersionResource) NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	name := ""
+	if len(subresources) > 0 {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name = accessor.GetName()
+		if len(name) == 0 {
+			return nil, fmt.Errorf("name is required")
+		}
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Post().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	name := accessor.GetName()
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	name := accessor.GetName()
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Put().
+		AbsPath(append(c.makeURLSegments(name), "status")...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(outBytes).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return err
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	if err := validateNamespaceWithOptionalName(c.namespace); err != nil {
+		return err
+	}
+
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	return result.Error()
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if err := validateNamespaceWithOptionalName(c.namespace); err != nil {
+		return nil, err
+	}
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	if list, ok := uncastObj.(*unstructured.UnstructuredList); ok {
+		return list, nil
+	}
+
+	list, err := uncastObj.(*unstructured.Unstructured).ToList()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	if err := validateNamespaceWithOptionalName(c.namespace); err != nil {
+		return nil, err
+	}
+	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Watch(ctx)
+}
+
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+
+func (c *dynamicResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	managedFields := accessor.GetManagedFields()
+	if len(managedFields) > 0 {
+		return nil, fmt.Errorf(`cannot apply an object with managed fields already set.
+		Use the client-go/applyconfigurations "UnstructructuredExtractor" to obtain the unstructured ApplyConfiguration for the given field manager that you can use/modify here to apply`)
+	}
+	patchOpts := opts.ToPatchOptions()
+
+	result := c.client.client.
+		Patch(types.ApplyPatchType).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(outBytes).
+		SpecificallyVersionedParams(&patchOpts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	retBytes, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+	uncastObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, retBytes)
+	if err != nil {
+		return nil, err
+	}
+	return uncastObj.(*unstructured.Unstructured), nil
+}
+func (c *dynamicResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return c.Apply(ctx, name, obj, opts, "status")
+}
+
+func validateNamespaceWithOptionalName(namespace string, name ...string) error {
+	if msgs := rest.IsValidPathSegmentName(namespace); len(msgs) != 0 {
+		return fmt.Errorf("invalid namespace %q: %v", namespace, msgs)
+	}
+	if len(name) > 1 {
+		panic("Invalid number of names")
+	} else if len(name) == 1 {
+		if msgs := rest.IsValidPathSegmentName(name[0]); len(msgs) != 0 {
+			return fmt.Errorf("invalid resource name %q: %v", name[0], msgs)
+		}
+	}
+	return nil
+}
+
+func (c *dynamicResourceClient) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -513,6 +513,7 @@ k8s.io/client-go/applyconfigurations/storage/v1alpha1
 k8s.io/client-go/applyconfigurations/storage/v1beta1
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
+k8s.io/client-go/dynamic
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/fake
 k8s.io/client-go/kubernetes/scheme


### PR DESCRIPTION
## What

Adds the ability to restrict CoreDNS to node-local (loopback) queries by
installing nftables rules in the `coredns-monitor` container, and drives that
behavior from the `externalDNSAccessPolicy` field on the cluster
`Infrastructure` resource.

## Why

By default CoreDNS on baremetal serves DNS on `*:53` over the host network,
which is reachable from off-node. This lets clusters opt into blocking that
external access. The new
`status.platformStatus.baremetal.externalDNSAccessPolicy` API field is the
control surface, so the policy can be changed at runtime.

## How

- **nftables rules** (`pkg/monitor/nftables_linux.go`): a single `inet`-family
  table `ocp_dns_filter` with an input chain (policy `accept`) that drops
  non-loopback TCP+UDP traffic to port 53. Loopback-delivered node-local
  queries fall through and are allowed. Rules are idempotent
  (`ensure`/`clean`/`checkCorednsFirewallRules`) and tagged with owner comments
  so we only touch our own rules. Non-Linux builds get stubs.
- **Reconcile** (`pkg/monitor/corednsmonitor.go`): each iteration ensures or
  cleans the rules based on `config.Node.BlockExternalDNS`, and cleans them on
  shutdown. Failures are logged, non-fatal — they must not block Corefile
  rendering.
- **Policy source** (`pkg/config/node.go`): `BlockExternalDNS` is read live from
  the API via `getExternalDNSBlocked` — a dynamic client GETs `Infrastructure`
  `cluster` and reads
  `status.platformStatus.baremetal.externalDNSAccessPolicy`. Only `"Deny"`
  blocks; `"Allow"`, an omitted field, or any read error → do not block
  (**fail-open**). The dynamic client is used because the typed field is not yet
  in the vendored `openshift/api`.

## Dependencies (outside this repo)

For the rules to actually be applied, the machine-config-operator must grant the
`coredns-monitor` container:
- `CAP_NET_ADMIN` (to program nftables), and
- RBAC `get` on `infrastructures.config.openshift.io` (to read the policy).

Until then this code is inert-but-safe (logs errors).

## Testing

- Unit tests for the policy → bool mapping (`externalDNSBlockedFromInfra`:
  Deny/Allow/omitted/absent-baremetal).
- Manually verified on a dev-scripts baremetal cluster: with the field unset no
  rules are created and external DNS resolves; patching the policy to `Deny`
  installs the drop rules and blocks off-node queries to `:53` while node-local
  lookups keep working; patching back to `Allow` removes the rules.

## Follow-up

Once `openshift/api` is bumped to a release containing
`ExternalDNSAccessPolicy`, the dynamic read can optionally be swapped for the
typed `openshift/client-go` config client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CoreDNS can now block external DNS access when the cluster’s external DNS access policy is set to **Deny**.
  * Loopback DNS queries remain allowed while external TCP and UDP traffic to port 53 is blocked.
  * The policy is evaluated during configuration reconciliation, with safe fail-open behavior when unavailable.
* **Documentation**
  * Added guidance on the external DNS access policy, required permissions, and platform limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->